### PR TITLE
'dark-theme' and 'goog-theme' year 'hover' state colors updated to improve readability

### DIFF
--- a/app-datepicker.html
+++ b/app-datepicker.html
@@ -445,6 +445,9 @@ Custom property | Description | Default
         color: var(--app-datepicker-button-color, #80cbc4);
         --paper-button-ink-color: var(--app-datepicker-button-ink-color, #bcbcbc);
       }
+      :host(.dark-theme) div.each-list-of-years:hover {
+        color: var(--app-datepicker-bg, #424242);
+      }
 
       /* goog theme */
       :host(.goog-theme) {
@@ -489,6 +492,9 @@ Custom property | Description | Default
       :host(.goog-theme) div.calendar-view > ::content > div.buttons > paper-button {
         color: var(--app-datepicker-button-color, #DA4336);
         --paper-button-ink-color: var(--app-datepicker-button-ink-color, #616161);
+      }
+      :host(.goog-theme) div.each-list-of-years:hover {
+        color: var(--app-datepicker-bg, #212121);
       }
 
     </style>


### PR DESCRIPTION
fixes #24

both `dark-theme` and `goog-theme` year `hover` state colors changed to improve readability.