### PR TITLE
fix: add `disable-dates` to `app-datepicker-dialog`

### DIFF
--- a/app-datepicker-dialog.html
+++ b/app-datepicker-dialog.html
@@ -28,6 +28,7 @@
     <app-datepicker id="datePicker" class="no-padding"
     first-day-of-week="[[firstDayOfWeek]]"
     disable-days="[[disableDays]]"
+    disable-dates="[[disableDates]]"
     min-date="[[minDate]]"
     max-date="[[maxDate]]"
     format="[[format]]"
@@ -56,6 +57,7 @@
         theme: String,
         firstDayOfWeek: Number,
         disableDays: Array,
+        disableDates: Array,
         minDate: String,
         maxDate: String,
         format: String,

--- a/app-datepicker.html
+++ b/app-datepicker.html
@@ -1077,7 +1077,7 @@ Custom property | Description | Default
           if (_maxDateObj) {
             _isMoreThanMaxDate = _currentDate.getTime() > _maxDateObj.getTime();
           }
-          _isDisableDates = this.disableDates.some(function(date) {
+          _isDisableDates = !this.disableDates || this.disableDates.some(function(date) {
             var _dateObj = this._convertDateStringToDateObject(date);
             return _dateObj && _currentDate.getTime() === _dateObj.getTime();
           }.bind(this));

--- a/app-datepicker.html
+++ b/app-datepicker.html
@@ -1077,7 +1077,7 @@ Custom property | Description | Default
           if (_maxDateObj) {
             _isMoreThanMaxDate = _currentDate.getTime() > _maxDateObj.getTime();
           }
-          _isDisableDates = !this.disableDates || this.disableDates.some(function(date) {
+          _isDisableDates = this.disableDates && this.disableDates.length && this.disableDates.some(function(date) {
             var _dateObj = this._convertDateStringToDateObject(date);
             return _dateObj && _currentDate.getTime() === _dateObj.getTime();
           }.bind(this));

--- a/test/app-datepicker-test.html
+++ b/test/app-datepicker-test.html
@@ -82,6 +82,7 @@
           });
 
           it('should support falsy values', function() {
+            datepicker.disableDays = [];
             datepicker.inputDate = '2016/01/01';
             datepicker.disableDates = undefined;
             Polymer.dom.flush();
@@ -89,6 +90,13 @@
             Polymer.dom.flush();
             datepicker.disableDates = '';
             Polymer.dom.flush();
+
+            var dates = datepicker.querySelectorAll('.each-days-of-month');
+            for (var i = 0; i < dates.length; i++) {
+              if (dates[i].getAttribute('aria-label')) {
+                expect(dates[i].classList.contains('is-disabled-day')).to.be.false;
+              }
+            }
           })
         });
 

--- a/test/app-datepicker-test.html
+++ b/test/app-datepicker-test.html
@@ -57,7 +57,7 @@
           });
         });
 
-        context('text for disableDates', function () {
+        context('test for disableDates', function () {
           it('should disable all dates in the array', function () {
             datepicker.inputDate = '2016/01/01';
             datepicker.disableDates = ['2016/01/02', '2016/01/03', '2016/01/04'];
@@ -80,6 +80,16 @@
             expect(thirdDay.getAttribute('aria-disabled')).to.equal('');
             expect(fourthDay.getAttribute('aria-disabled')).to.equal('');
           });
+
+          it('should support falsy values', function() {
+            datepicker.inputDate = '2016/01/01';
+            datepicker.disableDates = undefined;
+            Polymer.dom.flush();
+            datepicker.disableDates = null;
+            Polymer.dom.flush();
+            datepicker.disableDates = '';
+            Polymer.dom.flush();
+          })
         });
 
         context('test for minDate and maxDate', function () {


### PR DESCRIPTION
* Added `disable-dates` to `app-datepicker-dialog`
* Fixed a bug which caused no dates to display when disableDates was
undefined or null.

Closes #50 and closes #51