### PR TITLE
🐛 src: Fix blank calendar due to overloaded click handlers

### DIFF
--- a/src/app-datepicker.ts
+++ b/src/app-datepicker.ts
@@ -537,8 +537,7 @@ export class AppDatepicker extends LitElement {
      */
     const datepickerBodyContent: import('lit-element').TemplateResult =
       START_VIEW.YEAR_LIST === this._startView ?
-        this._renderDatepickerYearList() :
-        this._renderDatepickerCalendar();
+        this._renderDatepickerYearList() : this._renderDatepickerCalendar();
 
     return html`
     <div class="datepicker-header">${this._renderHeaderSelectorButton()}</div>
@@ -831,6 +830,19 @@ export class AppDatepicker extends LitElement {
       const isPreviousMonth = updateType === MONTH_UPDATE_TYPE.PREVIOUS;
       const initialX = totalDraggableDistance * -1;
       const newDx = totalDraggableDistance * (isPreviousMonth ? 0 : -2);
+      const dateDate = this._selectedDate;
+      const newM = dateDate.getUTCMonth() + (isPreviousMonth ? -1 : 1);
+      const newSelectedDate = new Date(dateDate.setUTCMonth(newM));
+
+      /**
+       * NOTE: Instead of debouncing/ throttling the animation when switching between
+       * calendar months, this prevents subsequent animation that can cause an issue
+       * where a blank calendar comes into view to be queued by ensuring the new updated
+       * selected date's month always fall between the defined `_min` and `_max` values.
+       * Not only does it prevents the aforementioned issue but also avoid adding too much
+       * delay in between animations. Happy spamming the animations as you wish! ðð
+       */
+      if (newM < this._min!.getUTCMonth() || newM > this._max!.getUTCMonth()) return;
 
       return this._animateCalendar({
         target: calendarViewFullCalendar,
@@ -838,10 +850,7 @@ export class AppDatepicker extends LitElement {
         to: newDx,
         postX: initialX,
         postTask: () => {
-          const dateDate = this._selectedDate;
-          const newM = dateDate.getUTCMonth() + (isPreviousMonth ? -1 : 1);
-
-          this._selectedDate = new Date(dateDate.setUTCMonth(newM));
+          this._selectedDate = newSelectedDate;
           return this.updateComplete;
         },
       });


### PR DESCRIPTION
When spamming the buttons to switch between calendar months, this queues
multiple task in the task queues. Each task queue is responsible for
updating the layout to determine whether or not buttons should be
rendered on screen for users to switch to the previous/ next calendar
month.

Some of the queuing tasks might be invalid if the new selected
date is less than the _min value or larger than the _max value. This
in turns causes an issue where animation continues to switch to the
subsequent calendar month and apparently that results in a blank
calendar.

To avoid such behavior, the patch adds a condition check to ensure that
the new selected date always falls between the defined value of _min
and _max. If the value happens to be out-of-range value, the
subsequent animation task(s) which is(are) already in the queue not get
executed.

Such fix avoids adding additional delay between the animations switching
between calendar months instead of implementing some kind of debouncing
or throttling approach. So, happy spamming the animations! 😄🎉

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/motss/app-datepicker/137)
<!-- Reviewable:end -->
