### PR TITLE
Fix empty datepicker calendar container issue

### DIFF
--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -623,7 +623,7 @@ export class Datepicker extends LitElement {
       const minTime = +this._min;
       const maxTime = +this._max;
 
-      if (getDateRange(minTime, maxTime) > 864e5) {
+      if (getDateRange(minTime, maxTime) >= 864e5) {
         const focusedDateTime = +this._focusedDate;
 
         let newValue = focusedDateTime;


### PR DESCRIPTION
## Changes
 * [x]  Adjust if statement to work with date range equal 1 day

## Issue: https://github.com/motss/app-datepicker/issues/187