### PR TITLE
refactor: Use `lit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@wdio/sauce-service": "^5.22.1",
         "@wdio/selenium-standalone-service": "^5.16.10",
         "@wdio/spec-reporter": "^5.23.0",
-        "axe-core": "^2.6.1",
+        "axe-core": "4.2.x",
         "env-cmd": "^10.1.0",
         "es-dev-server": "^2.1.0",
         "husky": "^4.3.0",
@@ -3244,11 +3244,10 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.4.tgz",
+      "integrity": "sha512-9AiDKFKUCWEQm1Kj4lcq7KFavLqSXdf2m/zJo+NVh4VXlW5iwXRJ6alkKmipCyYorsRnqsICH9XLubP1jBF+Og==",
       "dev": true,
-      "hasInstallScript": true,
       "engines": {
         "node": ">=4"
       }
@@ -14064,9 +14063,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
-      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.4.tgz",
+      "integrity": "sha512-9AiDKFKUCWEQm1Kj4lcq7KFavLqSXdf2m/zJo+NVh4VXlW5iwXRJ6alkKmipCyYorsRnqsICH9XLubP1jBF+Og==",
       "dev": true
     },
     "babel-plugin-dynamic-import-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@wdio/sauce-service": "^5.22.1",
         "@wdio/selenium-standalone-service": "^5.16.10",
         "@wdio/spec-reporter": "^5.23.0",
-        "axe-core": "^4.3.5",
+        "axe-core": "^2.6.1",
         "env-cmd": "^10.1.0",
         "es-dev-server": "^2.1.0",
         "husky": "^4.3.0",
@@ -3244,10 +3244,11 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
-      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
       "dev": true,
+      "hasInstallScript": true,
       "engines": {
         "node": ">=4"
       }
@@ -14063,9 +14064,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
-      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.6.1.tgz",
+      "integrity": "sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==",
       "dev": true
     },
     "babel-plugin-dynamic-import-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,13 @@
       "version": "4.6.0-rc.0",
       "license": "MIT",
       "dependencies": {
-        "@material/mwc-button": "^0.22.1",
-        "lit-element": "2.5.1",
-        "lit-html": "1.4.1",
+        "@material/mwc-button": "^0.25.3",
+        "lit": "^2.0.2",
         "nodemod": "2.8.4",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@reallyland/tsconfig": "~3.0",
+        "@reallyland/tsconfig": "^3.1.0",
         "@reallyland/tslint-config": "^1.1.1",
         "@skypack/package-check": "^0.2.2",
         "@types/mocha": "^7.0.2",
@@ -28,7 +27,7 @@
         "@wdio/sauce-service": "^5.22.1",
         "@wdio/selenium-standalone-service": "^5.16.10",
         "@wdio/spec-reporter": "^5.23.0",
-        "axe-core": "^4.2.2",
+        "axe-core": "^4.3.5",
         "env-cmd": "^10.1.0",
         "es-dev-server": "^2.1.0",
         "husky": "^4.3.0",
@@ -37,7 +36,7 @@
         "reify": "^0.20.12",
         "shx": "^0.3.2",
         "tslint": "^6.1.3",
-        "typescript": "~4.3",
+        "typescript": "^4.4.4",
         "webdriverio": "^5.23.0"
       },
       "engines": {
@@ -1654,103 +1653,117 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.4.tgz",
+      "integrity": "sha512-dJMha+4NFYdpnUJzRrWTFV5Hdp9QHWFuPnaoqonrKl4lGJVnYez9mu8ev9F/5KM47tjAjh22DuRHrdFDHfOijA=="
+    },
     "node_modules/@material/animation": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-R1QbY4fC6RBOoi4Dq/3yuD5OK0ts02WxGt1JXaddsdnO6szZJcfXm2aiCweU1GUpchoah+YzDBJrsmSoqFCKIg==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-OjxWJYSRNs4vnPe8NclaNn+TsNc8TR/wHusGtezF5F+wl+5mh+K69BMXAmURtq3idoRg4XaOSC/Ohk1ovD1fMQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/base": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-bCxGPqFQPh3rfBdqG+UvlrnRPSP2CzHhn0f44NqELY/SkmujIfS30rJOX965IKoD6lGdKWIfi/sAm03I81pZ7g==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-vy5SQt+jcwwdRFfBvtpVdpULUBujecVUKOXcopaQoi2XIzI5EBHuR4gPN0cd1yfmVEucD6p2fvVv2FJ3Ngr61w==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/dom": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-9XvFE2OuOZizYXF3ptyMcJuN/JHZA4vKq5lPLrIbcTXnd4DzJ7L4JrMcMb75xfjugxj8uaXjdfI62gwHfzP/aw==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-iUpZG6Bb2l/PfNV2Fb/pXfG1p4Bz4PC9A7ATPlKfcU5HioObcnYVc/+Hrtaw8eu28BNIc+VVROtbfpqG/YgKSQ==",
       "dependencies": {
-        "@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/feature-targeting": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-e72VDSIMrwF5aX4rkQcO1AHewX/ydWOujFtMBk4QD/asyDPKBv+bKwO6f/msM+Wqen8I+DbHC0PH/2K15gQ3pQ==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/mwc-base": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.22.1.tgz",
-      "integrity": "sha512-KtQf4lQUoTQuetfhfRbVJhsXVcpX74LP4JI/cLmx+SGbpG+pXXWf6VI2MvZY2UoHVEkldqPHndeuqctBoY7vgg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.25.3.tgz",
+      "integrity": "sha512-4wvxZ9dhPr0O4jjOHPmFyn77pafe+h1gHPlT9sbQ+ly8NY/fSn/TXn7/PbxgL8g4ZHxMvD3o7PJopg+6cbHp8Q==",
       "dependencies": {
-        "@material/base": "=12.0.0-canary.22d29cbb4.0",
-        "@material/dom": "=12.0.0-canary.22d29cbb4.0",
-        "lit-element": "^2.5.1",
+        "@lit/reactive-element": "1.0.0-rc.4",
+        "@material/base": "=14.0.0-canary.261f2db59.0",
+        "@material/dom": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "node_modules/@material/mwc-button": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.22.1.tgz",
-      "integrity": "sha512-Z+NOM+d7QkmIOGbVT7BA/rzLJMXGaxC4Bp+dXcm3ESu6ohPBtG878IyZGSGiMXXDtmAKgMAIp74z4gE/Y0j1pA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.25.3.tgz",
+      "integrity": "sha512-usHEKchj9hqetY7n0yebTz1Pk9Z+9W/sNZheFoSaiWQCv9XhtCdKkHH0MXTv8SpwxWuEKUf/XjtyvikGIcIn7w==",
       "dependencies": {
-        "@material/mwc-icon": "^0.22.1",
-        "@material/mwc-ripple": "^0.22.1",
-        "lit-element": "^2.5.1",
-        "lit-html": "^1.4.1",
+        "@material/mwc-icon": "^0.25.3",
+        "@material/mwc-ripple": "^0.25.3",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "node_modules/@material/mwc-icon": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.22.1.tgz",
-      "integrity": "sha512-LX4MUThlYEBfpTr1O53J27KbzFhPbe2dBGouY9piztCI3FObbRVQI+LXFlXJm6KU0BzemaQfz105ZAuLlPAN4g==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.25.3.tgz",
+      "integrity": "sha512-36076AWZIRSr8qYOLjuDDkxej/HA0XAosrj7TS1ZeLlUBnLUtbDtvc1S7KSa0hqez7ouzOqGaWK24yoNnTa2OA==",
       "dependencies": {
-        "lit-element": "^2.5.1",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "node_modules/@material/mwc-ripple": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.22.1.tgz",
-      "integrity": "sha512-QQyWWPBZ6veWNbBMWo8WQw0iY9QUjLLANorug8mPHv13ETdhwVUUozeKOY0ZCXWupNlqtap1Gd0IQjv6HVRMjA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.25.3.tgz",
+      "integrity": "sha512-G/gt/csxgME6/sAku3GiuB0O2LLvoPWsRTLq/9iABpaGLJjqaKHvNg/IVzNDdF3YZT7EORgR9cBWWl7umA4i4Q==",
       "dependencies": {
-        "@material/dom": "=12.0.0-canary.22d29cbb4.0",
-        "@material/mwc-base": "^0.22.1",
-        "@material/ripple": "=12.0.0-canary.22d29cbb4.0",
-        "lit-element": "^2.5.1",
-        "lit-html": "^1.4.1",
+        "@material/dom": "=14.0.0-canary.261f2db59.0",
+        "@material/mwc-base": "^0.25.3",
+        "@material/ripple": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "node_modules/@material/ripple": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-IzBtXi4EWx27Hkfd5Zkx/MrZAXJZe0AAQCo37Etl/af0/aJPIOyCOdHQiwoK2FqRH71pmNfUGrUWOeUxFyaSdw==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-3FLCLj8X7KrFfuYBHJg1b7Odb3V/AW7fxk3m1i1zhDnygKmlQ/abVucH1s2qbX3Y+JIiq+5/C5407h9BFtOf+A==",
       "dependencies": {
-        "@material/animation": "12.0.0-canary.22d29cbb4.0",
-        "@material/base": "12.0.0-canary.22d29cbb4.0",
-        "@material/dom": "12.0.0-canary.22d29cbb4.0",
-        "@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
-        "@material/theme": "12.0.0-canary.22d29cbb4.0",
+        "@material/animation": "14.0.0-canary.261f2db59.0",
+        "@material/base": "14.0.0-canary.261f2db59.0",
+        "@material/dom": "14.0.0-canary.261f2db59.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+        "@material/rtl": "14.0.0-canary.261f2db59.0",
+        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
+      "dependencies": {
+        "@material/theme": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/theme": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-r4xYCgc+CrbvDxCINVqXwAFWQ1WgV3s2+bUse/2iw53YqyemhhtzFjfp+DXLdC4zJSOuObWC45eaDKeseLMGMw==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
       "dependencies": {
-        "@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
@@ -1795,9 +1808,9 @@
       "hasInstallScript": true
     },
     "node_modules/@reallyland/tsconfig": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@reallyland/tsconfig/-/tsconfig-3.0.2.tgz",
-      "integrity": "sha512-a4lj2jtMC19MwkwjmHnjH1fw0TmUjfQ0RitxqX+LbV1ZzH51dGn3ZtWwnSjnpi/9sAeVKCGFmlUOhbC6UfbaHg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@reallyland/tsconfig/-/tsconfig-3.1.0.tgz",
+      "integrity": "sha512-935KKBLM3KsN5cfHHzwVo5imM0zGTUVku37a7BV55kwIrAVpNKE4ZR6RajXHFm6pr2FlpwbkjzzpJp0cwLcb6g==",
       "dev": true,
       "engines": {
         "node": ">= 14.15.3",
@@ -1971,9 +1984,9 @@
       }
     },
     "node_modules/@reallyland/tslint-config/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
       "dev": true
     },
     "node_modules/@reallyland/tslint-config/node_modules/tslint": {
@@ -2050,12 +2063,6 @@
         "tslint": "^5.0.0",
         "typescript": "^2.2.0 || ^3.0.0"
       }
-    },
-    "node_modules/@reallyland/tslint-config/node_modules/tslint-eslint-rules/node_modules/tslib": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-      "dev": true
     },
     "node_modules/@reallyland/tslint-config/node_modules/tslint-eslint-rules/node_modules/tsutils": {
       "version": "3.21.0",
@@ -2630,6 +2637,11 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
       "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "node_modules/@types/whatwg-url": {
       "version": "6.4.0",
@@ -3232,9 +3244,9 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
-      "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -4419,9 +4431,9 @@
       }
     },
     "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "node_modules/cosmiconfig": {
@@ -4937,15 +4949,6 @@
         "responselike": "1.0.2"
       }
     },
-    "node_modules/download/node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/download/node_modules/decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -5017,9 +5020,9 @@
       }
     },
     "node_modules/download/node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5995,9 +5998,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -6047,26 +6050,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/globule/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/got": {
@@ -7209,9 +7192,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
+      "integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -7376,18 +7359,37 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
-    "node_modules/lit-element": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
-      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
+    "node_modules/lit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
+      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
       "dependencies": {
-        "lit-html": "^1.1.1"
+        "@lit/reactive-element": "^1.0.0",
+        "lit-element": "^3.0.0",
+        "lit-html": "^2.0.0"
       }
     },
+    "node_modules/lit-element": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.1.tgz",
+      "integrity": "sha512-vs9uybH9ORyK49CFjoNGN85HM9h5bmisU4TQ63phe/+GYlwvY/3SIFYKdjV6xNvzz8v2MnVC+9+QOkPqh+Q3Ew==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0",
+        "lit-html": "^2.0.0"
+      }
+    },
+    "node_modules/lit-element/node_modules/@lit/reactive-element": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
+      "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
+    },
     "node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.1.tgz",
+      "integrity": "sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/lit-ntml": {
       "version": "2.20.0",
@@ -7408,6 +7410,11 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "node_modules/lit/node_modules/@lit/reactive-element": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
+      "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
     },
     "node_modules/load-json-file": {
       "version": "1.1.0",
@@ -9572,9 +9579,9 @@
       }
     },
     "node_modules/sauce-connect-launcher-update/node_modules/async": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-      "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
       "dev": true
     },
     "node_modules/saucelabs": {
@@ -10683,9 +10690,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10906,12 +10913,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
@@ -12717,103 +12718,117 @@
         "vary": "^1.1.2"
       }
     },
+    "@lit/reactive-element": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.4.tgz",
+      "integrity": "sha512-dJMha+4NFYdpnUJzRrWTFV5Hdp9QHWFuPnaoqonrKl4lGJVnYez9mu8ev9F/5KM47tjAjh22DuRHrdFDHfOijA=="
+    },
     "@material/animation": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-R1QbY4fC6RBOoi4Dq/3yuD5OK0ts02WxGt1JXaddsdnO6szZJcfXm2aiCweU1GUpchoah+YzDBJrsmSoqFCKIg==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-OjxWJYSRNs4vnPe8NclaNn+TsNc8TR/wHusGtezF5F+wl+5mh+K69BMXAmURtq3idoRg4XaOSC/Ohk1ovD1fMQ==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@material/base": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-bCxGPqFQPh3rfBdqG+UvlrnRPSP2CzHhn0f44NqELY/SkmujIfS30rJOX965IKoD6lGdKWIfi/sAm03I81pZ7g==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-vy5SQt+jcwwdRFfBvtpVdpULUBujecVUKOXcopaQoi2XIzI5EBHuR4gPN0cd1yfmVEucD6p2fvVv2FJ3Ngr61w==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@material/dom": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-9XvFE2OuOZizYXF3ptyMcJuN/JHZA4vKq5lPLrIbcTXnd4DzJ7L4JrMcMb75xfjugxj8uaXjdfI62gwHfzP/aw==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-iUpZG6Bb2l/PfNV2Fb/pXfG1p4Bz4PC9A7ATPlKfcU5HioObcnYVc/+Hrtaw8eu28BNIc+VVROtbfpqG/YgKSQ==",
       "requires": {
-        "@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
     "@material/feature-targeting": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-e72VDSIMrwF5aX4rkQcO1AHewX/ydWOujFtMBk4QD/asyDPKBv+bKwO6f/msM+Wqen8I+DbHC0PH/2K15gQ3pQ==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-CrVoGNu0ym52OPEKy3kgeNL2oSWOCBYbYxSH3GhERxCq5FwGBN+XmK/ZDLFVQlHYy3v8x4TqVEwXviCeumNTxQ==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@material/mwc-base": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.22.1.tgz",
-      "integrity": "sha512-KtQf4lQUoTQuetfhfRbVJhsXVcpX74LP4JI/cLmx+SGbpG+pXXWf6VI2MvZY2UoHVEkldqPHndeuqctBoY7vgg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.25.3.tgz",
+      "integrity": "sha512-4wvxZ9dhPr0O4jjOHPmFyn77pafe+h1gHPlT9sbQ+ly8NY/fSn/TXn7/PbxgL8g4ZHxMvD3o7PJopg+6cbHp8Q==",
       "requires": {
-        "@material/base": "=12.0.0-canary.22d29cbb4.0",
-        "@material/dom": "=12.0.0-canary.22d29cbb4.0",
-        "lit-element": "^2.5.1",
+        "@lit/reactive-element": "1.0.0-rc.4",
+        "@material/base": "=14.0.0-canary.261f2db59.0",
+        "@material/dom": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "@material/mwc-button": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.22.1.tgz",
-      "integrity": "sha512-Z+NOM+d7QkmIOGbVT7BA/rzLJMXGaxC4Bp+dXcm3ESu6ohPBtG878IyZGSGiMXXDtmAKgMAIp74z4gE/Y0j1pA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.25.3.tgz",
+      "integrity": "sha512-usHEKchj9hqetY7n0yebTz1Pk9Z+9W/sNZheFoSaiWQCv9XhtCdKkHH0MXTv8SpwxWuEKUf/XjtyvikGIcIn7w==",
       "requires": {
-        "@material/mwc-icon": "^0.22.1",
-        "@material/mwc-ripple": "^0.22.1",
-        "lit-element": "^2.5.1",
-        "lit-html": "^1.4.1",
+        "@material/mwc-icon": "^0.25.3",
+        "@material/mwc-ripple": "^0.25.3",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "@material/mwc-icon": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.22.1.tgz",
-      "integrity": "sha512-LX4MUThlYEBfpTr1O53J27KbzFhPbe2dBGouY9piztCI3FObbRVQI+LXFlXJm6KU0BzemaQfz105ZAuLlPAN4g==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.25.3.tgz",
+      "integrity": "sha512-36076AWZIRSr8qYOLjuDDkxej/HA0XAosrj7TS1ZeLlUBnLUtbDtvc1S7KSa0hqez7ouzOqGaWK24yoNnTa2OA==",
       "requires": {
-        "lit-element": "^2.5.1",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "@material/mwc-ripple": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.22.1.tgz",
-      "integrity": "sha512-QQyWWPBZ6veWNbBMWo8WQw0iY9QUjLLANorug8mPHv13ETdhwVUUozeKOY0ZCXWupNlqtap1Gd0IQjv6HVRMjA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.25.3.tgz",
+      "integrity": "sha512-G/gt/csxgME6/sAku3GiuB0O2LLvoPWsRTLq/9iABpaGLJjqaKHvNg/IVzNDdF3YZT7EORgR9cBWWl7umA4i4Q==",
       "requires": {
-        "@material/dom": "=12.0.0-canary.22d29cbb4.0",
-        "@material/mwc-base": "^0.22.1",
-        "@material/ripple": "=12.0.0-canary.22d29cbb4.0",
-        "lit-element": "^2.5.1",
-        "lit-html": "^1.4.1",
+        "@material/dom": "=14.0.0-canary.261f2db59.0",
+        "@material/mwc-base": "^0.25.3",
+        "@material/ripple": "=14.0.0-canary.261f2db59.0",
+        "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
     },
     "@material/ripple": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-IzBtXi4EWx27Hkfd5Zkx/MrZAXJZe0AAQCo37Etl/af0/aJPIOyCOdHQiwoK2FqRH71pmNfUGrUWOeUxFyaSdw==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-3FLCLj8X7KrFfuYBHJg1b7Odb3V/AW7fxk3m1i1zhDnygKmlQ/abVucH1s2qbX3Y+JIiq+5/C5407h9BFtOf+A==",
       "requires": {
-        "@material/animation": "12.0.0-canary.22d29cbb4.0",
-        "@material/base": "12.0.0-canary.22d29cbb4.0",
-        "@material/dom": "12.0.0-canary.22d29cbb4.0",
-        "@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
-        "@material/theme": "12.0.0-canary.22d29cbb4.0",
+        "@material/animation": "14.0.0-canary.261f2db59.0",
+        "@material/base": "14.0.0-canary.261f2db59.0",
+        "@material/dom": "14.0.0-canary.261f2db59.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
+        "@material/rtl": "14.0.0-canary.261f2db59.0",
+        "@material/theme": "14.0.0-canary.261f2db59.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@material/rtl": {
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-bVnXBbUsHs57+EXdeFbcwaKy3lT/itI/qTLmJ88ar0qaGEujO1GmESHm3ioqkeo4kQpTfDhBwQGeEi1aDaTdFg==",
+      "requires": {
+        "@material/theme": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
     "@material/theme": {
-      "version": "12.0.0-canary.22d29cbb4.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-12.0.0-canary.22d29cbb4.0.tgz",
-      "integrity": "sha512-r4xYCgc+CrbvDxCINVqXwAFWQ1WgV3s2+bUse/2iw53YqyemhhtzFjfp+DXLdC4zJSOuObWC45eaDKeseLMGMw==",
+      "version": "14.0.0-canary.261f2db59.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.261f2db59.0.tgz",
+      "integrity": "sha512-bUqyFT0QF8Nxx02fekt3CXIfC9DEPOPdo2hjgdtvhrNP+vftbkI2tKZ5/uRUnVA+zqQAOyIl5z6FOMg4fyemCA==",
       "requires": {
-        "@material/feature-targeting": "12.0.0-canary.22d29cbb4.0",
+        "@material/feature-targeting": "14.0.0-canary.261f2db59.0",
         "tslib": "^2.1.0"
       }
     },
@@ -12857,9 +12872,9 @@
       "integrity": "sha512-ztcFO4F2XEmcQ0ePattqVtDXcfl4G90xXshUfLJ2vJOjQDy15CSkpZ3++WIHvKRx8S1oCUUVdQXdcq9DKGL8Wg=="
     },
     "@reallyland/tsconfig": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@reallyland/tsconfig/-/tsconfig-3.0.2.tgz",
-      "integrity": "sha512-a4lj2jtMC19MwkwjmHnjH1fw0TmUjfQ0RitxqX+LbV1ZzH51dGn3ZtWwnSjnpi/9sAeVKCGFmlUOhbC6UfbaHg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@reallyland/tsconfig/-/tsconfig-3.1.0.tgz",
+      "integrity": "sha512-935KKBLM3KsN5cfHHzwVo5imM0zGTUVku37a7BV55kwIrAVpNKE4ZR6RajXHFm6pr2FlpwbkjzzpJp0cwLcb6g==",
       "dev": true
     },
     "@reallyland/tslint-config": {
@@ -12991,9 +13006,9 @@
           }
         },
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
           "dev": true
         },
         "tslint": {
@@ -13051,12 +13066,6 @@
             "tsutils": "^3.0.0"
           },
           "dependencies": {
-            "tslib": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-              "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-              "dev": true
-            },
             "tsutils": {
               "version": "3.21.0",
               "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -13588,6 +13597,11 @@
       "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
       "dev": true
     },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
     "@types/whatwg-url": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
@@ -14049,9 +14063,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
-      "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
       "dev": true
     },
     "babel-plugin-dynamic-import-node": {
@@ -14978,9 +14992,9 @@
       }
     },
     "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cosmiconfig": {
@@ -15390,14 +15404,6 @@
             "lowercase-keys": "1.0.0",
             "normalize-url": "2.0.1",
             "responselike": "1.0.2"
-          },
-          "dependencies": {
-            "lowercase-keys": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-              "dev": true
-            }
           }
         },
         "decompress-response": {
@@ -15462,9 +15468,9 @@
           }
         },
         "lowercase-keys": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
           "dev": true
         },
         "normalize-url": {
@@ -16236,9 +16242,9 @@
       }
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -16273,22 +16279,6 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "got": {
@@ -17129,9 +17119,9 @@
       }
     },
     "keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
+      "integrity": "sha512-vqNHbAc8BBsxk+7QBYLW0Y219rWcClspR6WSeoHYKG5mnsSoOH+BL1pWq02DDCVdvvuUny5rkBlzMRzoqc+GIg==",
       "dev": true,
       "requires": {
         "json-buffer": "3.0.1"
@@ -17274,18 +17264,46 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
-    "lit-element": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
-      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
+    "lit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
+      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
       "requires": {
-        "lit-html": "^1.1.1"
+        "@lit/reactive-element": "^1.0.0",
+        "lit-element": "^3.0.0",
+        "lit-html": "^2.0.0"
+      },
+      "dependencies": {
+        "@lit/reactive-element": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
+          "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
+        }
+      }
+    },
+    "lit-element": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.1.tgz",
+      "integrity": "sha512-vs9uybH9ORyK49CFjoNGN85HM9h5bmisU4TQ63phe/+GYlwvY/3SIFYKdjV6xNvzz8v2MnVC+9+QOkPqh+Q3Ew==",
+      "requires": {
+        "@lit/reactive-element": "^1.0.0",
+        "lit-html": "^2.0.0"
+      },
+      "dependencies": {
+        "@lit/reactive-element": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
+          "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ=="
+        }
       }
     },
     "lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.1.tgz",
+      "integrity": "sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==",
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "lit-ntml": {
       "version": "2.20.0",
@@ -19033,9 +19051,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-          "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+          "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
           "dev": true
         }
       }
@@ -19926,9 +19944,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
     "typical": {
@@ -20106,14 +20124,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      },
-      "dependencies": {
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        }
       }
     },
     "wcwidth": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@wdio/sauce-service": "^5.22.1",
     "@wdio/selenium-standalone-service": "^5.16.10",
     "@wdio/spec-reporter": "^5.23.0",
-    "axe-core": "^4.3.5",
+    "axe-core": "^2.6.1",
     "env-cmd": "^10.1.0",
     "es-dev-server": "^2.1.0",
     "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -74,14 +74,13 @@
     }
   },
   "dependencies": {
-    "@material/mwc-button": "^0.22.1",
-    "lit-element": "2.5.1",
-    "lit-html": "1.4.1",
+    "@material/mwc-button": "^0.25.3",
+    "lit": "^2.0.2",
     "nodemod": "2.8.4",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@reallyland/tsconfig": "~3.0",
+    "@reallyland/tsconfig": "^3.1.0",
     "@reallyland/tslint-config": "^1.1.1",
     "@skypack/package-check": "^0.2.2",
     "@types/mocha": "^7.0.2",
@@ -93,7 +92,7 @@
     "@wdio/sauce-service": "^5.22.1",
     "@wdio/selenium-standalone-service": "^5.16.10",
     "@wdio/spec-reporter": "^5.23.0",
-    "axe-core": "^4.2.2",
+    "axe-core": "^4.3.5",
     "env-cmd": "^10.1.0",
     "es-dev-server": "^2.1.0",
     "husky": "^4.3.0",
@@ -102,7 +101,7 @@
     "reify": "^0.20.12",
     "shx": "^0.3.2",
     "tslint": "^6.1.3",
-    "typescript": "~4.3",
+    "typescript": "^4.4.4",
     "webdriverio": "^5.23.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@wdio/sauce-service": "^5.22.1",
     "@wdio/selenium-standalone-service": "^5.16.10",
     "@wdio/spec-reporter": "^5.23.0",
-    "axe-core": "^2.6.1",
+    "axe-core": "4.2.x",
     "env-cmd": "^10.1.0",
     "es-dev-server": "^2.1.0",
     "husky": "^4.3.0",

--- a/src/app-datepicker-icons.ts
+++ b/src/app-datepicker-icons.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-element';
+import { html } from 'lit';
 
 // tslint:disable:max-line-length
 export const iconChevronLeft = html`<svg height="24" viewBox="0 0 24 24" width="24"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path></svg>`;

--- a/src/common-styles.ts
+++ b/src/common-styles.ts
@@ -1,4 +1,4 @@
-import { css } from 'lit-element';
+import { css } from 'lit';
 
 export const resetButton = css`
 button {

--- a/src/custom_typings.ts
+++ b/src/custom_typings.ts
@@ -37,6 +37,9 @@ type HTMLTableCellElementPart = /** Both td and th have the same instance */
   | 'calendar-weekday';
 type HTMLTableElementPart = 'table';
 type HTMLTableRowElementPart = 'weekdays';
+/**
+ * FIXME: Not able to extend HTMLElement when `types` is used.
+ */
 export type HTMLElementPart =
   | HTMLButtonElementPart
   | HTMLDivElementPart

--- a/src/datepicker-dialog.ts
+++ b/src/datepicker-dialog.ts
@@ -274,7 +274,7 @@ export class DatepickerDialog extends LitElement {
   }
 
   protected override async getUpdateComplete() {
-    const result = await super.getUpdateComplete()
+    const result = await super.getUpdateComplete();
 
     await this._datepicker?.updateComplete;
 

--- a/src/datepicker-dialog.ts
+++ b/src/datepicker-dialog.ts
@@ -274,7 +274,7 @@ export class DatepickerDialog extends LitElement {
   }
 
   protected override async getUpdateComplete() {
-    await this._datepicker!.updateComplete;
+    await this._datepicker?.updateComplete;
 
     super.requestUpdate();
 
@@ -317,7 +317,7 @@ export class DatepickerDialog extends LitElement {
     return `0${val}`.slice(-2);
   }
 
-  private async _setToday() {
+  private _setToday() {
     const today = getResolvedDate();
     const fy = today.getFullYear();
     const m = today.getMonth();
@@ -326,7 +326,7 @@ export class DatepickerDialog extends LitElement {
     this._datepicker!.value = [`${fy}`].concat([1 + m, d].map(this._padStart)).join('-');
   }
 
-  private async _updateValue() {
+  private _updateValue() {
     this.value = this._datepicker!.value;
   }
 

--- a/src/datepicker-dialog.ts
+++ b/src/datepicker-dialog.ts
@@ -274,11 +274,11 @@ export class DatepickerDialog extends LitElement {
   }
 
   protected override async getUpdateComplete() {
+    const result = await super.getUpdateComplete()
+
     await this._datepicker?.updateComplete;
 
-    super.requestUpdate();
-
-    return await this.updateComplete;
+    return result;
   }
 
   protected override render() {

--- a/src/datepicker-dialog.ts
+++ b/src/datepicker-dialog.ts
@@ -4,7 +4,8 @@ export interface DatepickerDialogClosed extends Pick<DatepickerDialog, 'value'> 
 export type DatepickerDialogOpened = DatepickerDialogClosed & DatepickerFirstUpdated;
 
 import '@material/mwc-button/mwc-button.js';
-import { css, html, LitElement, property, query } from 'lit-element';
+import { css, html, LitElement } from 'lit';
+import { property, query, queryAsync } from 'lit/decorators.js';
 import type { WeekNumberType } from 'nodemod/dist/calendar/typings.js';
 
 import { datepickerVariables } from './common-styles.js';
@@ -12,7 +13,6 @@ import type {
   DatepickerFirstUpdated,
   DatepickerValueUpdated,
   FocusTrap,
-  HTMLElementPart,
   StartView,
 } from './custom_typings.js';
 import { KEY_CODES_MAP } from './custom_typings.js';
@@ -25,100 +25,97 @@ import { setFocusTrap } from './helpers/set-focus-trap.js';
 import { toFormattedDateString } from './helpers/to-formatted-date-string.js';
 
 export class DatepickerDialog extends LitElement {
-  static get styles() {
-    // tslint:disable: max-line-length
-    return [
-      datepickerVariables,
-      css`
-      :host {
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
+  public static override styles = [
+    datepickerVariables,
+    css`
+    :host {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
 
-        display: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        pointer-events: none;
-        z-index: var(--app-datepicker-dialog-z-index, 24);
-        -webkit-tap-highlight-color: rgba(0,0,0,0);
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: var(--app-datepicker-dialog-z-index, 24);
+      -webkit-tap-highlight-color: rgba(0,0,0,0);
+    }
+
+    .scrim,
+    .content-container {
+      pointer-events: auto;
+    }
+
+    .scrim {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: var(--app-datepicker-dialog-scrim-bg-color, rgba(0, 0, 0, .55));
+      visibility: hidden;
+      z-index: 22;
+    }
+
+    .content-container {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      max-width: 100%;
+      max-height: 100%;
+      background-color: var(--app-datepicker-bg-color, #fff);
+      transform: translate3d(-50%, -50%, 0);
+      border-radius: var(--app-datepicker-dialog-border-radius, 8px);
+      will-change: transform, opacity;
+      overflow: hidden;
+      visibility: hidden;
+      opacity: 0;
+      z-index: 23;
+      box-shadow: 0 24px 38px 3px rgba(0, 0, 0, 0.14),
+                  0 9px 46px 8px rgba(0, 0, 0, 0.12),
+                  0 11px 15px -7px rgba(0, 0, 0, 0.4);
+    }
+
+    .datepicker {
+      --app-datepicker-border-top-left-radius: 8px;
+      --app-datepicker-border-top-right-radius: 8px;
+    }
+
+    .actions-container {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+
+      margin: 0;
+      padding: 12px;
+      background-color: inherit;
+      --mdc-theme-primary: var(--app-datepicker-accent-color, #1a73e8);
+    }
+
+    mwc-button[dialog-confirm] {
+      margin: 0 0 0 8px;
+    }
+
+    .clear {
+      margin: 0 auto 0 0;
+    }
+
+    /**
+      * NOTE: IE11-only fix via CSS hack.
+      * Visit https://bit.ly/2DEUNZu|CSS for more relevant browsers' hacks.
+      */
+    @media screen and (-ms-high-contrast: none) {
+      mwc-button[dialog-dismiss] {
+        min-width: 10ch;
       }
-
-      .scrim,
-      .content-container {
-        pointer-events: auto;
-      }
-
-      .scrim {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: var(--app-datepicker-dialog-scrim-bg-color, rgba(0, 0, 0, .55));
-        visibility: hidden;
-        z-index: 22;
-      }
-
-      .content-container {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        max-width: 100%;
-        max-height: 100%;
-        background-color: var(--app-datepicker-bg-color, #fff);
-        transform: translate3d(-50%, -50%, 0);
-        border-radius: var(--app-datepicker-dialog-border-radius, 8px);
-        will-change: transform, opacity;
-        overflow: hidden;
-        visibility: hidden;
-        opacity: 0;
-        z-index: 23;
-        box-shadow: 0 24px 38px 3px rgba(0, 0, 0, 0.14),
-                    0 9px 46px 8px rgba(0, 0, 0, 0.12),
-                    0 11px 15px -7px rgba(0, 0, 0, 0.4);
-      }
-
-      .datepicker {
-        --app-datepicker-border-top-left-radius: 8px;
-        --app-datepicker-border-top-right-radius: 8px;
-      }
-
-      .actions-container {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-
-        margin: 0;
-        padding: 12px;
-        background-color: inherit;
-        --mdc-theme-primary: var(--app-datepicker-accent-color, #1a73e8);
-      }
-
-      mwc-button[dialog-confirm] {
-        margin: 0 0 0 8px;
-      }
-
-      .clear {
-        margin: 0 auto 0 0;
-      }
-
-      /**
-       * NOTE: IE11-only fix via CSS hack.
-       * Visit https://bit.ly/2DEUNZu|CSS for more relevant browsers' hacks.
-       */
-      @media screen and (-ms-high-contrast: none) {
-        mwc-button[dialog-dismiss] {
-          min-width: 10ch;
-        }
-      }
-      `,
-    ];
-    // tslint:enable: max-line-length
-  }
+    }
+    `,
+  ];
+  // tslint:enable: max-line-length
 
   @property({ type: Number, reflect: true })
   public firstDayOfWeek: number = 0;
@@ -151,7 +148,7 @@ export class DatepickerDialog extends LitElement {
   public disabledDays: string = '';
 
   @property({ type: String })
-  public disabledDates?: string;
+  public disabledDates: string = '';
 
   @property({ type: String })
   public weekLabel: string = 'Wk';
@@ -174,18 +171,20 @@ export class DatepickerDialog extends LitElement {
   @property({ type: Boolean })
   public alwaysResetValue: boolean = false;
 
-  @query('.content-container')
-  private _contentContainer?: HTMLDivElement;
+  @query('.content-container') private _contentContainer?: HTMLDivElement;
 
-  @query('mwc-button[dialog-confirm]')
-  private _dialogConfirm?: HTMLElement;
+  @query('mwc-button[dialog-confirm]') private _dialogConfirm?: HTMLElement;
+
+  @queryAsync('.datepicker') private _datepicker!: Promise<Datepicker>;
+
+  @queryAsync('.scrim') private _scrim!: Promise<HTMLDivElement>;
 
   private _hasNativeWebAnimation: boolean = 'animate' in HTMLElement.prototype;
   private _focusable?: HTMLElement;
   private _focusTrap?: FocusTrap;
   private _opened: boolean = false;
 
-  public async open(): Promise<void> {
+  public async open() {
     await this.updateComplete;
 
     if (this._opened) return;
@@ -193,14 +192,17 @@ export class DatepickerDialog extends LitElement {
     this.removeAttribute('aria-hidden');
     this.style.display = 'block';
     this._opened = true;
+    const datepicker = await this._datepicker;
 
-    if (this.alwaysResetValue && this._datepicker) this._datepicker.value = this.value;
+    if (this.alwaysResetValue && datepicker) datepicker.value = this.value;
 
-    await this.requestUpdate();
+    this.requestUpdate();
+    await this.updateComplete;
 
     const contentContainer = this._contentContainer!;
+    const scrim = await this._scrim;
 
-    this._scrim!.style.visibility = contentContainer.style.visibility = 'visible';
+    scrim.style.visibility = contentContainer.style.visibility = 'visible';
 
     await animateElement(contentContainer, {
       hasNativeWebAnimation: this._hasNativeWebAnimation,
@@ -227,13 +229,15 @@ export class DatepickerDialog extends LitElement {
     });
   }
 
-  public async close(): Promise<void> {
+  public async close() {
     await this.updateComplete;
 
     if (!this._opened) return;
 
+    const scrim = await this._scrim;
+
     this._opened = false;
-    this._scrim!.style.visibility = '';
+    scrim.style.visibility = '';
 
     const contentContainer = this._contentContainer!;
 
@@ -257,11 +261,11 @@ export class DatepickerDialog extends LitElement {
       this, 'datepicker-dialog-closed', { opened: false, value: this.value });
   }
 
-  protected shouldUpdate() {
+  protected override shouldUpdate(): boolean {
     return !this.hasAttribute('aria-hidden');
   }
 
-  protected firstUpdated() {
+  protected override firstUpdated(): void {
     this.setAttribute('role', 'dialog');
     this.setAttribute('aria-label', 'datepicker');
     this.setAttribute('aria-modal', 'true');
@@ -277,15 +281,22 @@ export class DatepickerDialog extends LitElement {
   }
 
   // tslint:disable-next-line: function-name
-  protected _getUpdateComplete() {
-    const datepicker = this._datepicker;
+  // protected _getUpdateComplete() {
+  //   const datepicker = this._datepicker;
 
-    return (
-      datepicker ? datepicker.updateComplete : Promise.resolve()
-    ).then(() => super._getUpdateComplete());
+  //   return (
+  //     datepicker ? datepicker.updateComplete : Promise.resolve()
+  //   ).then(() => super.performUpdate());
+  // }
+  protected override async getUpdateComplete() {
+    await (await this._datepicker).updateComplete;
+
+    super.requestUpdate();
+
+    return await this.updateComplete;
   }
 
-  protected render() {
+  protected override render() {
     return html`
     <div class="scrim" part="scrim" @click="${this.close}"></div>
 
@@ -321,17 +332,18 @@ export class DatepickerDialog extends LitElement {
     return `0${val}`.slice(-2);
   }
 
-  private _setToday() {
+  private async _setToday() {
     const today = getResolvedDate();
     const fy = today.getFullYear();
     const m = today.getMonth();
     const d = today.getDate();
+    const datepicker = await this._datepicker;
 
-    this._datepicker!.value = [`${fy}`].concat([1 + m, d].map(this._padStart)).join('-');
+    datepicker.value = [`${fy}`].concat([1 + m, d].map(this._padStart)).join('-');
   }
 
-  private _updateValue() {
-    this.value = this._datepicker!.value;
+  private async _updateValue() {
+    this.value = (await this._datepicker).value;
   }
 
   private _update() {
@@ -353,21 +365,13 @@ export class DatepickerDialog extends LitElement {
     this._updateValue();
   }
 
-  private get _datepicker() {
-    return this.shadowRoot!.querySelector<Datepicker>('.datepicker');
-  }
-
-  private get _scrim() {
-    return this.shadowRoot!.querySelector<HTMLDivElement>('.scrim');
-  }
-
 }
 
 declare global {
   // #region HTML element type extension
-  interface HTMLElement {
-    part: HTMLElementPart;
-  }
+  // interface HTMLElement {
+  //   part: HTMLElementPart;
+  // }
   // #endregion HTML element type extension
 
   interface HTMLElementEventMap {

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -509,7 +509,8 @@ export class Datepicker extends LitElement {
 
   @queryAsync('.calendars-container') public calendarsContainer!: Promise<HTMLDivElement>;
 
-  @queryAsync('.datepicker-body__calendar-view') public datepickerBodyCalendarView!: Promise<HTMLDivElement>;
+  @queryAsync('.datepicker-body__calendar-view')
+  public datepickerBodyCalendarView!: Promise<HTMLDivElement>;
 
   private _min: Date;
   private _max: Date;
@@ -587,7 +588,7 @@ export class Datepicker extends LitElement {
     if ('calendar' === this._startView) {
       firstFocusableElement = (
         this.inline ?
-          this.shadowRoot!.querySelector('.btn__month-selector') as unknown as HTMLButtonElement:
+          this.shadowRoot!.querySelector('.btn__month-selector') as unknown as HTMLButtonElement :
           this._buttonSelectorYear
       )!;
     } else {

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -10,7 +10,7 @@ import {
   LitElement,
   TemplateResult,
 } from 'lit';
-import { eventOptions, property, query, queryAsync } from 'lit/decorators.js';
+import { eventOptions, property, query } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -507,11 +507,6 @@ export class Datepicker extends LitElement {
   @query('.year-list-view__list-item')
   private _yearViewListItem?: HTMLButtonElement;
 
-  @queryAsync('.calendars-container') public calendarsContainer!: Promise<HTMLDivElement>;
-
-  @queryAsync('.datepicker-body__calendar-view')
-  public datepickerBodyCalendarView!: Promise<HTMLDivElement>;
-
   private _min: Date;
   private _max: Date;
   private _hasMin: boolean = false;
@@ -638,7 +633,7 @@ export class Datepicker extends LitElement {
       }
 
       if ('calendar' === startView && null == this._tracker) {
-        const calendarsContainer = await this.calendarsContainer;
+        const calendarsContainer = this.calendarsContainer;
 
         let $down = false;
         let $move = false;
@@ -1177,6 +1172,10 @@ export class Datepicker extends LitElement {
     const dateBM = dateB.getUTCMonth();
 
     return dateAFy === dateBFY && dateAM === dateBM;
+  }
+
+  public get calendarsContainer() {
+    return this.shadowRoot!.querySelector<HTMLDivElement>('.calendars-container');
   }
 
 }

--- a/src/helpers/is-valid-date.ts
+++ b/src/helpers/is-valid-date.ts
@@ -1,3 +1,3 @@
-export function isValidDate(date: string, dateDate: Date) {
+export function isValidDate(date: string | undefined, dateDate: Date) {
   return !(date == null || !(dateDate instanceof Date) || isNaN(+dateDate));
 }

--- a/src/tests/app-datepicker-dialog/a11y.spec.ts
+++ b/src/tests/app-datepicker-dialog/a11y.spec.ts
@@ -49,7 +49,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::a11y`, () => {
 
   afterEach(async () => {
     await browser.executeAsync(async (a, done) => {
-      const el = document.body.querySelector<DatepickerDialog>(a)!;
+      const el = document.body.querySelector(a) as DatepickerDialog;
 
       if (el) document.body.removeChild(el);
 
@@ -73,7 +73,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::a11y`, () => {
           await (window as any).axeReport(el);
 
           done({ type: 'success' });
-        } catch (e) {
+        } catch (error) {
+          const e = error as Error;
+
           done({
             type: 'error',
             name: e.name,

--- a/src/tests/app-datepicker-dialog/attributes.spec.ts
+++ b/src/tests/app-datepicker-dialog/attributes.spec.ts
@@ -37,7 +37,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<DatepickerDialog>(a)!;
+      const el = document.body.querySelector(a) as DatepickerDialog;
 
       if (el) document.body.removeChild(el);
 
@@ -52,7 +52,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
       `./src/tests/snapshots/${DATEPICKER_DIALOG_NAME}/attributes-0-${browserName}.png`);
 
     await browser.executeAsync(async (a, done) => {
-      const el = document.body.querySelector<DatepickerDialog>(a)!;
+      const el = document.body.querySelector(a) as DatepickerDialog;
 
       el.setAttribute('min', '2020-01-15');
       el.setAttribute('value', '2020-01-17');
@@ -77,8 +77,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
     ];
 
     const values: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       done([
         n.getAttribute('firstdayofweek'),
@@ -109,8 +109,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedMin = '2000-01-01';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('min', c);
 
@@ -127,8 +127,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedMax = '2020-02-27';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('max', c);
 
@@ -145,8 +145,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedValue = '2020-02-20';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('value', c);
 
@@ -169,8 +169,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedStartview: StartView = 'calendar';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('startview', c);
 
@@ -187,8 +187,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedFirstdayofweek = '1';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('firstdayofweek', c);
 
@@ -204,8 +204,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
     type A = [boolean, boolean];
 
     const values: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('showweeknumber', '');
 
@@ -222,8 +222,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedWeeknumbertype: WeekNumberType = 'first-4-day-week';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('weeknumbertype', c);
 
@@ -239,8 +239,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
     type A = [boolean, boolean];
 
     const values: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('landscape', '');
 
@@ -257,8 +257,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedLocale: string = 'ja-JP';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('locale', c);
 
@@ -281,8 +281,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedDisableddays: string = '3,5';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('disableddays', c);
 
@@ -310,13 +310,13 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedDisableddates: string = '2020-02-02,2020-02-15';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
 
       n.setAttribute('disableddates', c);
 
       await n.updateComplete;
 
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       done([
         n.getAttribute('disableddates'),
@@ -344,8 +344,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
       prop2,
       attr,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('dragratio', `${c}`);
 
@@ -367,8 +367,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
     const expectedWeeklabel: string = '周数';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
       const initialLabel = n.weekLabel;
 
       n.setAttribute('weeklabel', c);
@@ -403,7 +403,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
       initialClearLabel,
       ...others
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
       const initialLabel = n.clearLabel;
 
@@ -411,7 +411,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
       await n.updateComplete;
 
-      const clearButton = root.querySelector<HTMLElement>(b);
+      const clearButton = root.querySelector(b) as HTMLElement;
 
       done([
         initialLabel,
@@ -433,7 +433,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
       initialDismissLabel,
       ...others
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
       const initialLabel = n.dismissLabel;
 
@@ -441,7 +441,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
       await n.updateComplete;
 
-      const clearButton = root.querySelector<HTMLElement>(b);
+      const clearButton = root.querySelector(b) as HTMLElement;
 
       done([
         initialLabel,
@@ -463,7 +463,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
       initialConfirmLabel,
       ...others
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
       const initialLabel = n.confirmLabel;
 
@@ -471,7 +471,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
       await n.updateComplete;
 
-      const clearButton = root.querySelector<HTMLElement>(b);
+      const clearButton = root.querySelector(b) as HTMLElement;
 
       done([
         initialLabel,
@@ -501,7 +501,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
         return $n;
       };
 
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const initialNoFocusTrap = n.noFocusTrap;
 
       n.min = '2000-01-01';
@@ -510,7 +510,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
       await n.updateComplete;
 
-      const confirmButton = n.querySelector<HTMLElement>(b);
+      const confirmButton = n.querySelector(b) as HTMLElement;
 
       confirmButton?.focus();
 
@@ -552,9 +552,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
 
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
-      const n2 = root.querySelector<Datepicker>(b)!;
+      const n2 = root.querySelector(b) as Datepicker;
       const initialAlwaysResetValue = n.alwaysResetValue;
 
       n.min = '2000-01-01';
@@ -569,7 +569,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
       await n.open();
       await n.updateComplete;
 
-      const focusedDate = n2.shadowRoot!.querySelector<HTMLTableCellElement>(c);
+      const focusedDate = n2.shadowRoot!.querySelector(c) as HTMLTableCellElement;
 
       done([
         initialAlwaysResetValue,
@@ -613,8 +613,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::attributes`, () => {
     const expectedFirstdayofweek: string = '1';
     const expectedDisableddays: string = '3,5';
     const values: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.setAttribute('firstdayofweek', c);
       n.setAttribute('disableddays', d);

--- a/src/tests/app-datepicker-dialog/events.spec.ts
+++ b/src/tests/app-datepicker-dialog/events.spec.ts
@@ -42,8 +42,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::events`, () => {
         await n.open();
         await n.updateComplete;
 
-        const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
-        const n3 = n2.shadowRoot!.querySelector<HTMLDivElement>('.calendars-container')!;
+        const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
+        const n3 = n2.shadowRoot!.querySelector('.calendars-container') as unknown as HTMLDivElement;
 
         domTriggerKey(n3, KEY_CODES_MAP.ARROW_LEFT);
 

--- a/src/tests/app-datepicker-dialog/events.spec.ts
+++ b/src/tests/app-datepicker-dialog/events.spec.ts
@@ -43,7 +43,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::events`, () => {
         await n.updateComplete;
 
         const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
-        const n3 = n2.shadowRoot!.querySelector('.calendars-container') as unknown as HTMLDivElement;
+        const n3 = n2.shadowRoot!.querySelector(
+          '.calendars-container'
+        ) as unknown as HTMLDivElement;
 
         domTriggerKey(n3, KEY_CODES_MAP.ARROW_LEFT);
 

--- a/src/tests/app-datepicker-dialog/gestures.spec.ts
+++ b/src/tests/app-datepicker-dialog/gestures.spec.ts
@@ -23,7 +23,7 @@ describe('gestures', () => {
     done();
   }, DATEPICKER_DIALOG_NAME);
   const cleanup = () => browser.executeAsync((a, done) => {
-    const el = document.body.querySelector<DatepickerDialog>(a);
+    const el = document.body.querySelector(a) as DatepickerDialog;
 
     if (el) document.body.removeChild(el);
 

--- a/src/tests/app-datepicker-dialog/initial-render.spec.ts
+++ b/src/tests/app-datepicker-dialog/initial-render.spec.ts
@@ -165,7 +165,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
 
         const root = n.shadowRoot!;
         const n2 = root.querySelector('.scrim') as unknown as HTMLDivElement;
-        const n3s = Array.from(root.querySelectorAll('mwc-button')) as unknown as HTMLButtonElement[];
+        const n3s = Array.from(
+          root.querySelectorAll('mwc-button')
+        ) as unknown as HTMLButtonElement[];
 
         done([
           getComputedStyle(n2 as unknown as Element).visibility === 'visible',

--- a/src/tests/app-datepicker-dialog/initial-render.spec.ts
+++ b/src/tests/app-datepicker-dialog/initial-render.spec.ts
@@ -32,7 +32,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
 
     afterEach(async () => {
       await browser.executeAsync((a, done) => {
-        const el = document.body.querySelector<DatepickerDialog>(a)!;
+        const el = document.body.querySelector(a) as DatepickerDialog;
 
         if (el) document.body.removeChild(el);
 
@@ -44,7 +44,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
       const browserName = browser.capabilities.browserName;
 
       await browser.executeAsync(async (a, done) => {
-        const n = document.body.querySelector<DatepickerDialog>(a)!;
+        const n = document.body.querySelector(a) as DatepickerDialog;
 
         await n.open();
         await n.updateComplete;
@@ -61,7 +61,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
       type A = [string, string, string, string];
 
       const values: A = await browser.executeAsync(async (a, done) => {
-        const n = document.body.querySelector<DatepickerDialog>(a)!;
+        const n = document.body.querySelector(a) as DatepickerDialog;
 
         done([
           n.getAttribute('role'),
@@ -91,13 +91,13 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
       type A = [boolean, boolean];
 
       const values: A = await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<DatepickerDialog>(a)!;
-        const n2 = n.shadowRoot!.querySelector<Datepicker>(b);
-        const n3 = n.shadowRoot!.querySelector<HTMLDivElement>('.scrim')!;
+        const n = document.body.querySelector(a) as DatepickerDialog;
+        const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
+        const n3 = n.shadowRoot!.querySelector('.scrim') as unknown as HTMLDivElement;
 
         done([
           n2 == null,
-          getComputedStyle(n3).visibility === 'hidden',
+          getComputedStyle(n3 as unknown as Element).visibility === 'hidden',
         ] as A);
       }, DATEPICKER_DIALOG_NAME, DATEPICKER_NAME);
 
@@ -111,7 +111,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
         prop,
         todayValue,
       ]: A = await browser.executeAsync(async (a, done) => {
-        const n = document.body.querySelector<DatepickerDialog>(a)!;
+        const n = document.body.querySelector(a) as DatepickerDialog;
 
         /**
          * NOTE: Get the today's date from the browser instead of
@@ -133,14 +133,14 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
 
     it(`renders year list view`, async () => {
       const hasYearListView: boolean = await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<DatepickerDialog>(a)!;
+        const n = document.body.querySelector(a) as DatepickerDialog;
 
         n.startView = 'yearList';
 
         await n.open();
         await n.updateComplete;
 
-        const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+        const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
         done(
           n2.shadowRoot!.querySelector('.datepicker-body__year-list-view') == null
@@ -158,17 +158,17 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
         hasActionButtons,
         actionLabels,
       ]: A = await browser.executeAsync(async (a, done) => {
-        const n = document.body.querySelector<DatepickerDialog>(a)!;
+        const n = document.body.querySelector(a) as DatepickerDialog;
 
         await n.open();
         await n.updateComplete;
 
         const root = n.shadowRoot!;
-        const n2 = root.querySelector<HTMLDivElement>('.scrim')!;
-        const n3s = Array.from(root.querySelectorAll<HTMLButtonElement>('mwc-button')!);
+        const n2 = root.querySelector('.scrim') as unknown as HTMLDivElement;
+        const n3s = Array.from(root.querySelectorAll('mwc-button')) as unknown as HTMLButtonElement[];
 
         done([
-          getComputedStyle(n2).visibility === 'visible',
+          getComputedStyle(n2 as unknown as Element).visibility === 'visible',
           n3s.length === 3,
           n3s.map(o => o.textContent),
         ]);
@@ -199,7 +199,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::initial_render`, () => {
 
       for (const part of parts) {
         const result: A = await browser.executeAsync(async (a, [b, c], done) => {
-          const n = document.body.querySelector<DatepickerDialog>(a)!;
+          const n = document.body.querySelector(a) as DatepickerDialog;
 
           if (c) {
             await n.open();

--- a/src/tests/app-datepicker-dialog/keyboards.spec.ts
+++ b/src/tests/app-datepicker-dialog/keyboards.spec.ts
@@ -16,9 +16,9 @@ import {
 describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
   const focusElement = async (selector: string, inDialog: boolean = false) => {
     return browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
-      const n3 = (d ? n : n2).shadowRoot!.querySelector<HTMLElement>(c)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
+      const n3 = (d ? n : n2).shadowRoot!.querySelector(c) as HTMLElement;
 
       n3.focus();
 
@@ -63,7 +63,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<DatepickerDialog>(a);
+      const el = document.body.querySelector(a) as DatepickerDialog;
 
       if (el) document.body.removeChild(el);
 
@@ -75,10 +75,10 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
     await tapElements(['.btn__year-selector'], ['Space']);
 
     const hasYearListView: boolean = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
-      const yearListView = n2.shadowRoot!.querySelector<HTMLDivElement>(c)!;
+      const yearListView = n2.shadowRoot!.querySelector(c) as HTMLDivElement;
 
       done(yearListView != null);
     }, DATEPICKER_DIALOG_NAME, DATEPICKER_NAME, '.datepicker-body__year-list-view');
@@ -88,7 +88,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
 
   it(`switches to calendar view`, async () => {
     await browser.executeAsync(async (a, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.startView = 'yearList';
 
@@ -100,10 +100,10 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
     await tapElements(['.btn__calendar-selector'], ['Space']);
 
     const hasCalendarView: boolean = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
-      const yearListView = n2.shadowRoot!.querySelector<HTMLDivElement>(c)!;
+      const yearListView = n2.shadowRoot!.querySelector(c) as HTMLDivElement;
 
       done(yearListView != null);
     }, DATEPICKER_DIALOG_NAME, DATEPICKER_NAME, '.datepicker-body__calendar-view');
@@ -120,10 +120,10 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
     ], ['Space']);
 
     const hasYearListView: boolean = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
-      const yearListView = n2.shadowRoot!.querySelector<HTMLDivElement>(c)!;
+      const yearListView = n2.shadowRoot!.querySelector(c) as HTMLDivElement;
 
       done(yearListView != null);
     }, DATEPICKER_DIALOG_NAME, DATEPICKER_NAME, '.datepicker-body__year-list-view');
@@ -134,13 +134,13 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
       hasCalendarView,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       const root = n2.shadowRoot!;
 
-      const yearListView = root.querySelector<HTMLDivElement>(c)!;
-      const focusedDate = root.querySelector<HTMLTableCellElement>(d)!;
+      const yearListView = root.querySelector(c) as HTMLDivElement;
+      const focusedDate = root.querySelector(d) as HTMLTableCellElement;
 
       done([
         yearListView != null,
@@ -168,8 +168,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
       prop,
       prop2,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       done([
         n.value,
@@ -193,15 +193,15 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: B = await browser.executeAsync(async (a, b, c, d, e, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       const root = n2.shadowRoot!;
 
-      const yearSelectorButton = root.querySelector<HTMLButtonElement>(c)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(d)!;
+      const yearSelectorButton = root.querySelector(c) as HTMLButtonElement;
+      const calendarLabel = root.querySelector(d) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(e), o => o.textContent);
+        root.querySelectorAll(e), o => o.textContent);
 
       done([
         n.value,
@@ -250,12 +250,12 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
       cssDisplay,
       ariaHiddenAttr,
     ]: A = await browser.executeAsync(async (a, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
 
       await n.updateComplete;
 
       done([
-        getComputedStyle(n).display,
+        getComputedStyle(n as unknown as Element).display,
         n.getAttribute('aria-hidden'),
       ] as A);
     }, DATEPICKER_DIALOG_NAME);
@@ -275,14 +275,14 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
       prop2,
       focusedDateContent,
     ]: C = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n2.value = '2020-02-13';
 
       await n2.updateComplete;
 
-      const focusedDate = n2.shadowRoot!.querySelector<HTMLTableCellElement>(c)!;
+      const focusedDate = n2.shadowRoot!.querySelector(c) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -302,13 +302,13 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
       cssDisplay,
       ariaHiddenAttr,
     ]: B = await browser.executeAsync(async (a, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
 
       await n.updateComplete;
 
       done([
         n.value,
-        getComputedStyle(n).display,
+        getComputedStyle(n as unknown as Element).display,
         n.getAttribute('aria-hidden'),
         // === '2020-02-13'
       ] as B);
@@ -333,8 +333,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
       initialVal,
       todayValue,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       const padStart = (v: number) => `0${v}`.slice(-2);
       const today = new Date();
@@ -357,8 +357,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
     await browser.keys(['Space']);
 
     const prop: B = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       done(n2.value as B);
     }, DATEPICKER_DIALOG_NAME, DATEPICKER_NAME);
@@ -372,9 +372,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
 
   const focusCalendarsContainer = async (): Promise<string> => {
     return await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
-      const n3 = n2.shadowRoot!.querySelector<HTMLElement>(c)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
+      const n3 = n2.shadowRoot!.querySelector(c) as HTMLElement;
 
       n3.focus();
 
@@ -399,9 +399,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
     await focusCalendarsContainer();
 
     return browser.executeAsync(async (a, b, c, d, e, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
-      const n3 = n2.shadowRoot!.querySelector<HTMLDivElement>(c)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
+      const n3 = n2.shadowRoot!.querySelector(c) as HTMLDivElement;
 
       const opt: any = { keyCode: d, altKey: e };
       const ev = new CustomEvent('keyup', opt);
@@ -424,10 +424,10 @@ describe(`${DATEPICKER_DIALOG_NAME}::keyboards`, () => {
     await browserKeys(key, altKey);
 
     const [prop, prop2, content]: C = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
-      const focusedDate = n2.shadowRoot!.querySelector<HTMLTableCellElement>(c)!;
+      const focusedDate = n2.shadowRoot!.querySelector(c) as HTMLTableCellElement;
 
       done([
         n.value,

--- a/src/tests/app-datepicker-dialog/mouses.spec.ts
+++ b/src/tests/app-datepicker-dialog/mouses.spec.ts
@@ -19,7 +19,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
   const clickElements = async (classes: string[], prepareOptions?: PrepareOptions) => {
     if (prepareOptions) {
       await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<DatepickerDialog>(a)!;
+        const n = document.body.querySelector(a) as DatepickerDialog;
 
         const { props, attrs }: PrepareOptions = b;
 
@@ -55,9 +55,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
     for (const cls of classes) {
       if (isSafari) {
         await browser.executeAsync(async (a, b, c, done) => {
-          const n = document.body.querySelector<DatepickerDialog>(a)!;
-          const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
-          const n3 = n2.shadowRoot!.querySelector<HTMLElement>(c)!;
+          const n = document.body.querySelector(a) as DatepickerDialog;
+          const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
+          const n3 = n2.shadowRoot!.querySelector(c) as HTMLElement;
 
           if (n3 instanceof HTMLButtonElement || n3.tagName === 'MWC-BUTTON') {
             n3.click();
@@ -107,7 +107,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<DatepickerDialog>(a);
+      const el = document.body.querySelector(a) as DatepickerDialog;
 
       if (el) document.body.removeChild(el);
 
@@ -119,10 +119,10 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
     await clickElements(['.btn__year-selector']);
 
     const hasYearListView: boolean = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
-      const yearListView = n2.shadowRoot!.querySelector<HTMLDivElement>(c);
+      const yearListView = n2.shadowRoot!.querySelector(c) as HTMLDivElement;
 
       done(yearListView != null);
     }, DATEPICKER_DIALOG_NAME, DATEPICKER_NAME, '.datepicker-body__year-list-view');
@@ -138,10 +138,10 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
     });
 
     const hasCalendarView: boolean = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
-      const calendarView = n2.shadowRoot!.querySelector<HTMLDivElement>(c);
+      const calendarView = n2.shadowRoot!.querySelector(c) as HTMLDivElement;
 
       done(calendarView != null);
     }, DATEPICKER_DIALOG_NAME, DATEPICKER_NAME, '.datepicker-body__calendar-view');
@@ -168,15 +168,15 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, e, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       const root = n2.shadowRoot!;
 
-      const yearSelectorButton = root.querySelector<HTMLButtonElement>(c)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(d)!;
+      const yearSelectorButton = root.querySelector(c) as HTMLButtonElement;
+      const calendarLabel = root.querySelector(d) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(e), o => o.textContent);
+        root.querySelectorAll(e), o => o.textContent);
 
       done([
         n.value,
@@ -220,14 +220,14 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       const root = n2.shadowRoot!;
 
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         calendarLabel.outerHTML,
@@ -262,14 +262,14 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       const root = n2.shadowRoot!;
 
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         calendarLabel.outerHTML,
@@ -307,12 +307,12 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       prop2,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       const root = n2.shadowRoot!;
 
-      const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+      const focusedDate = root.querySelector(c) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -340,9 +340,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       cssDisplay,
       ariaHiddenAttr,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
 
-      const dialogDismissButton = n.shadowRoot!.querySelector<HTMLElement>(b)!;
+      const dialogDismissButton = n.shadowRoot!.querySelector(b) as HTMLElement;
 
       const dialogClosed = new Promise((yay) => {
         let timer = -1;
@@ -363,7 +363,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       await dialogClosed;
 
       done([
-        getComputedStyle(n).display,
+        getComputedStyle(n as unknown as Element).display,
         n.getAttribute('aria-hidden'),
       ] as A);
     }, DATEPICKER_DIALOG_NAME, `.actions-container > mwc-button[dialog-dismiss]`);
@@ -387,13 +387,13 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       ariaHiddenAttr,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
 
-      const dialogConfirmButton = root.querySelector<HTMLElement>(c)!;
-      const n2 = root.querySelector<Datepicker>(b)!;
+      const dialogConfirmButton = root.querySelector(c) as HTMLElement;
+      const n2 = root.querySelector(b) as Datepicker;
 
-      const focusedDate = n2.shadowRoot!.querySelector<HTMLTableCellElement>(d)!;
+      const focusedDate = n2.shadowRoot!.querySelector(d) as HTMLTableCellElement;
 
       const propVal = n.value;
       const propVal2 = n2.value;
@@ -422,7 +422,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
         propVal2,
         n.value,
 
-        getComputedStyle(n).display,
+        getComputedStyle(n as unknown as Element).display,
         n.getAttribute('aria-hidden'),
         focusedDateVal,
       ] as A);
@@ -451,9 +451,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
       prop,
       todayValue,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
-      const n2 = root.querySelector<Datepicker>(b)!;
+      const n2 = root.querySelector(b) as Datepicker;
 
       const padStart = (v: number) => `0${v}`.slice(-2);
       const today = new Date();
@@ -471,7 +471,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::mouses`, () => {
 
       const propVal = n2.value;
 
-      const clearButton = root.querySelector<HTMLElement>(c)!;
+      const clearButton = root.querySelector(c) as HTMLElement;
 
       clearButton.click();
 

--- a/src/tests/app-datepicker-dialog/properties.spec.ts
+++ b/src/tests/app-datepicker-dialog/properties.spec.ts
@@ -36,7 +36,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<DatepickerDialog>(a)!;
+      const el = document.body.querySelector(a) as DatepickerDialog;
 
       if (el) document.body.removeChild(el);
 
@@ -51,7 +51,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
       `./src/tests/snapshots/${DATEPICKER_DIALOG_NAME}/properties-0-${browserName}.png`);
 
     await browser.executeAsync(async (a, done) => {
-      const el = document.body.querySelector<DatepickerDialog>(a)!;
+      const el = document.body.querySelector(a) as DatepickerDialog;
 
       el.min = '2020-01-15';
       el.value = '2020-01-17';
@@ -73,8 +73,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
     ];
 
     const values: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       done([
         n.firstDayOfWeek,
@@ -100,8 +100,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedMin = '2000-01-01';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.min = c;
 
@@ -121,8 +121,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedMax = '2020-02-27';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.min = '2000-01-01';
       n.max = c;
@@ -143,8 +143,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedValue = '2020-02-20';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.min = '2000-01-01';
       n.max = '2020-12-31';
@@ -166,8 +166,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedStartView: StartView = 'calendar';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.startView = c;
 
@@ -187,8 +187,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedFirstDayOfWeek = 1;
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.firstDayOfWeek = c;
 
@@ -208,8 +208,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedShowWeekNumber: boolean = true;
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.showWeekNumber = c;
 
@@ -229,8 +229,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedWeekNumberType: WeekNumberType = 'first-4-day-week';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.weekNumberType = c;
 
@@ -250,8 +250,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedLandscape: boolean = true;
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.landscape = c;
 
@@ -271,8 +271,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedLocale: string = 'ja-JP';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.locale = c;
 
@@ -292,8 +292,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedDisabledDays: string = '3,5';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.disabledDays = c;
 
@@ -313,8 +313,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const expectedDisabledDates: string = '2020-02-02,2020-02-15';
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.disabledDates = c;
 
@@ -334,13 +334,13 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
     const dragRatio = .5;
     const values: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.querySelector<DatepickerDialog>(a)!;
+      const n = document.querySelector(a) as DatepickerDialog;
 
       n.dragRatio = c;
 
       await n.updateComplete;
 
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       done([
         n.dragRatio,
@@ -359,8 +359,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
       initialLabel,
       ...others
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
       const iniialWeekLabel = n.weekLabel;
 
       n.weekLabel = c;
@@ -386,7 +386,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
       initialClearLabel,
       ...others
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
       const initialLabel = n.clearLabel;
 
@@ -394,7 +394,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
       await n.updateComplete;
 
-      const clearButton = root.querySelector<HTMLElement>(b);
+      const clearButton = root.querySelector(b) as HTMLElement;
 
       done([
         initialLabel,
@@ -415,7 +415,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
       initialDismissLabel,
       ...others
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
       const initialLabel = n.dismissLabel;
 
@@ -423,7 +423,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
       await n.updateComplete;
 
-      const clearButton = root.querySelector<HTMLElement>(b);
+      const clearButton = root.querySelector(b) as HTMLElement;
 
       done([
         initialLabel,
@@ -444,7 +444,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
       initialConfirmLabel,
       ...others
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
       const initialLabel = n.confirmLabel;
 
@@ -452,7 +452,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
       await n.updateComplete;
 
-      const clearButton = root.querySelector<HTMLElement>(b);
+      const clearButton = root.querySelector(b) as HTMLElement;
 
       done([
         initialLabel,
@@ -480,7 +480,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
         return $n;
       };
 
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const initialNoFocusTrap = n.noFocusTrap;
 
       n.min = '2000-01-01';
@@ -489,7 +489,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
       await n.updateComplete;
 
-      const confirmButton = n.querySelector<HTMLElement>(b);
+      const confirmButton = n.querySelector(b) as HTMLElement;
 
       confirmButton?.focus();
 
@@ -529,9 +529,9 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
 
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
       const root = n.shadowRoot!;
-      const n2 = root.querySelector<Datepicker>(b)!;
+      const n2 = root.querySelector(b) as Datepicker;
       const initialAlwaysResetValue = n.alwaysResetValue;
 
       n.min = '2000-01-01';
@@ -546,7 +546,7 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
       await n.open();
       await n.updateComplete;
 
-      const focusedDate = n2.shadowRoot!.querySelector<HTMLTableCellElement>(c);
+      const focusedDate = n2.shadowRoot!.querySelector(c) as HTMLTableCellElement;
 
       done([
         initialAlwaysResetValue,
@@ -577,8 +577,8 @@ describe(`${DATEPICKER_DIALOG_NAME}::properties`, () => {
     const expectedFirstDayOfWeek: number = 1;
     const expectedDisabledDays: string = '3,5';
     const values: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<DatepickerDialog>(a)!;
-      const n2 = n.shadowRoot!.querySelector<Datepicker>(b)!;
+      const n = document.body.querySelector(a) as DatepickerDialog;
+      const n2 = n.shadowRoot!.querySelector(b) as Datepicker;
 
       n.firstDayOfWeek = c;
       n.disabledDays = d;

--- a/src/tests/app-datepicker/a11y.spec.ts
+++ b/src/tests/app-datepicker/a11y.spec.ts
@@ -49,7 +49,7 @@ describe('a11y', () => {
 
   afterEach(async () => {
     await browser.executeAsync(async (a, done) => {
-      const el = document.body.querySelector<Datepicker>(a)!;
+      const el = document.body.querySelector(a) as Datepicker;
 
       if (el) document.body.removeChild(el);
 
@@ -64,7 +64,7 @@ describe('a11y', () => {
     ].map<Promise<A11yReport>>(async (startView) => {
       const report = await browser.executeAsync(async (a, b, done) => {
         try {
-          const el = document.body.querySelector<Datepicker>(a)!;
+          const el = document.body.querySelector(a) as Datepicker;
 
           el.startView = b;
 
@@ -73,7 +73,9 @@ describe('a11y', () => {
           await (window as any).axeReport(el);
 
           done({ type: 'success' });
-        } catch (e) {
+        } catch (error) {
+          const e = error as Error;
+
           done({
             type: 'error',
             name: e.name,

--- a/src/tests/app-datepicker/attributes.spec.ts
+++ b/src/tests/app-datepicker/attributes.spec.ts
@@ -36,7 +36,7 @@ describe('attributes', () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<Datepicker>(a)!;
+      const el = document.body.querySelector(a) as Datepicker;
 
       document.body.removeChild(el);
 
@@ -72,7 +72,7 @@ describe('attributes', () => {
       lastDisabledDateContent,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.value = '2020-01-17';
       n.setAttribute('min', '2020-01-15');
@@ -80,7 +80,7 @@ describe('attributes', () => {
 
       const root = n.shadowRoot!;
 
-      const disabledDates = Array.from(root.querySelectorAll<HTMLTableCellElement>(b));
+      const disabledDates = Array.from(root.querySelectorAll(b)) as HTMLTableCellElement[];
       const lastDisabledDate = disabledDates[disabledDates.length - 1];
 
       const focusedDate = root.querySelector(c);
@@ -115,7 +115,7 @@ describe('attributes', () => {
       firstDisabledDateContent,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.value = '2020-01-15';
       n.min = '2000-01-01';
@@ -125,8 +125,8 @@ describe('attributes', () => {
 
       const root = n.shadowRoot!;
 
-      const firstDisabledDate = root.querySelector<HTMLTableCellElement>(b)!;
-      const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+      const firstDisabledDate = root.querySelector(b) as HTMLTableCellElement;
+      const focusedDate = root.querySelector(c) as HTMLTableCellElement;
 
       done([
         n.max,
@@ -157,7 +157,7 @@ describe('attributes', () => {
       attr,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.max = '2020-12-31';
@@ -165,7 +165,7 @@ describe('attributes', () => {
 
       await n.updateComplete;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -190,13 +190,13 @@ describe('attributes', () => {
       attr,
       hasYearListView,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.setAttribute('startview', 'yearList' as StartView);
 
       await n.updateComplete;
 
-      const yearListView = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+      const yearListView = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
       done([
         n.startView,
@@ -218,7 +218,7 @@ describe('attributes', () => {
       firstWeekdayLabelContent,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -228,8 +228,8 @@ describe('attributes', () => {
 
       const root = n.shadowRoot!;
 
-      const firstWeekdayLabel = root.querySelector<HTMLTableHeaderCellElement>(b)!;
-      const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+      const firstWeekdayLabel = root.querySelector(b) as HTMLTableCellElement;
+      const focusedDate = root.querySelector(c) as HTMLTableCellElement;
 
       done([
         n.firstDayOfWeek,
@@ -265,7 +265,7 @@ describe('attributes', () => {
       weekNumberLabelContent,
       weekNumbersContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.value = '2020-01-15';
       n.setAttribute('showweeknumber', '');
@@ -274,9 +274,9 @@ describe('attributes', () => {
 
       const root = n.shadowRoot!;
 
-      const weekNumberLabel = root.querySelector<HTMLTableHeaderCellElement>(b)!;
+      const weekNumberLabel = root.querySelector(b) as HTMLTableCellElement;
       const weekNumbers = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(c), o => o.outerHTML);
+        root.querySelectorAll(c), o => o.outerHTML);
 
       done([
         n.showWeekNumber,
@@ -317,7 +317,7 @@ describe('attributes', () => {
       attr,
       weekNumbersContents,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.value = '2020-01-15';
       n.showWeekNumber = true;
@@ -326,7 +326,7 @@ describe('attributes', () => {
       await n.updateComplete;
 
       const weekNumbers = Array.from(
-        n.shadowRoot!.querySelectorAll<HTMLTableCellElement>(b), o => o.outerHTML);
+        n.shadowRoot!.querySelectorAll(b), o => o.outerHTML);
 
       done([
         n.weekNumberType,
@@ -355,7 +355,7 @@ describe('attributes', () => {
       attr,
       cssDisplay,
     ]: A = await browser.executeAsync(async (a, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.setAttribute('landscape', '');
 
@@ -364,7 +364,7 @@ describe('attributes', () => {
       done([
         n.landscape,
         n.getAttribute('landscape'),
-        getComputedStyle(n).display,
+        getComputedStyle(n as unknown as Element).display,
       ] as A);
     }, DATEPICKER_NAME);
 
@@ -382,7 +382,7 @@ describe('attributes', () => {
       focusedDateContent,
       weekdayLabelsContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -392,9 +392,9 @@ describe('attributes', () => {
 
       const root = n.shadowRoot!;
 
-      const focusedDate = root.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = root.querySelector(b) as HTMLTableCellElement;
       const weekdayLabels = Array.from(
-        root.querySelectorAll<HTMLTableHeaderCellElement>(c), o => o.outerHTML);
+        root.querySelectorAll(c), o => o.outerHTML);
 
       done([
         n.locale,
@@ -435,7 +435,7 @@ describe('attributes', () => {
       attr,
       disabledDatesContents,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -444,7 +444,7 @@ describe('attributes', () => {
       await n.updateComplete;
 
       const disabledDates = Array.from(
-        n.shadowRoot!.querySelectorAll<HTMLTableCellElement>(b), o => o.outerHTML);
+        n.shadowRoot!.querySelectorAll(b), o => o.outerHTML);
 
       done([
         n.disabledDays,
@@ -480,7 +480,7 @@ describe('attributes', () => {
       attr,
       disabledDatesContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -489,7 +489,7 @@ describe('attributes', () => {
       await n.updateComplete;
 
       const disabledDates = Array.from(
-        n.shadowRoot!.querySelectorAll<HTMLTableCellElement>(b), o => o.outerHTML);
+        n.shadowRoot!.querySelectorAll(b), o => o.outerHTML);
 
       done([
         n.disabledDates,
@@ -509,20 +509,20 @@ describe('attributes', () => {
   });
 
   it(`renders with defined 'inline'`, async () => {
-    type A = [boolean, string, null];
+    type A = [boolean, string, HTMLElement | null];
 
     const [
       prop,
       attr,
       noDatepickerHeader,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.setAttribute('inline', '');
 
       await n.updateComplete;
 
-      const datepickerHeader = n.shadowRoot!.querySelector<HTMLDivElement>(b);
+      const datepickerHeader = n.shadowRoot!.querySelector(b) as HTMLDivElement | null;
 
       done([
         n.inline,
@@ -544,7 +544,7 @@ describe('attributes', () => {
       prop,
       attr,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.setAttribute('dragratio', `${b}`);
 
@@ -569,7 +569,7 @@ describe('attributes', () => {
       attr,
       weekNumberLabelContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.value = '2020-01-15';
       n.showWeekNumber = true;
@@ -577,7 +577,7 @@ describe('attributes', () => {
 
       await n.updateComplete;
 
-      const weekNumberLabel = n.shadowRoot!.querySelector<HTMLTableHeaderCellElement>(b)!;
+      const weekNumberLabel = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.weekLabel,
@@ -617,7 +617,7 @@ describe('attributes', () => {
         focusedDateContent,
         disabledDatesContent,
       ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
         n.min = '2000-01-01';
         n.value = '2020-01-15';
@@ -634,9 +634,9 @@ describe('attributes', () => {
 
         const root = n.shadowRoot!;
 
-        const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+        const focusedDate = root.querySelector(c) as HTMLTableCellElement;
         const disabledDates = Array.from(
-          root.querySelectorAll<HTMLTableCellElement>(d), o => o.outerHTML);
+          root.querySelectorAll(d), o => o.outerHTML);
 
         done([
           n.firstDayOfWeek,

--- a/src/tests/app-datepicker/edge-cases.spec.ts
+++ b/src/tests/app-datepicker/edge-cases.spec.ts
@@ -42,7 +42,7 @@ describe('edge cases', () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<Datepicker>(a)!;
+      const el = document.body.querySelector(a) as Datepicker;
 
       document.body.removeChild(el);
 
@@ -54,9 +54,9 @@ describe('edge cases', () => {
     type A = [string, string];
 
     const getValues = () => browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const calendarLabel = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+      const calendarLabel = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
       done([
         n.value,
@@ -93,7 +93,7 @@ describe('edge cases', () => {
     prepareOptions?: PrepareOptions
   ): Promise<B> => {
     await browser.executeAsync(async (a, b: PrepareOptions, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       if (b) {
         const attrs = b.attrs ?? {};
@@ -124,9 +124,9 @@ describe('edge cases', () => {
     await browserKeys(key, altKey);
 
     const [prop, content]: B = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -284,7 +284,7 @@ describe('edge cases', () => {
         valueProp,
         focusedDateContent,
       ]: A = await browser.executeAsync(async (a, b, c, d, e, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
         n.min = b;
         n.max = c;
@@ -294,7 +294,7 @@ describe('edge cases', () => {
           /** Loop until all renders complete (Chrome needs this but not FF) */
         }
 
-        const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(e);
+        const focusedDate = n.shadowRoot!.querySelector(e) as HTMLTableCellElement;
 
         done([
           n.min,

--- a/src/tests/app-datepicker/events.spec.ts
+++ b/src/tests/app-datepicker/events.spec.ts
@@ -116,7 +116,7 @@ describe('events', () => {
 
         await n.updateComplete;
 
-        const n2 = n.shadowRoot!.querySelector<HTMLElement>('.calendars-container')!;
+        const n2 = n.shadowRoot!.querySelector('.calendars-container') as unknown as HTMLElement;
 
         domTriggerKey(n2, KEY_CODES_MAP.ARROW_LEFT);
 
@@ -188,7 +188,7 @@ describe('events', () => {
         timer = window.setTimeout(() => yay(null), 15e3);
       });
 
-      const n2 = n.shadowRoot!.querySelector<HTMLElement>(b)!;
+      const n2 = n.shadowRoot!.querySelector(b) as HTMLElement;
 
       if (n2 instanceof HTMLButtonElement || n2.tagName === 'MWC-BUTTON') {
         n2.click();

--- a/src/tests/app-datepicker/gestures.spec.ts
+++ b/src/tests/app-datepicker/gestures.spec.ts
@@ -24,7 +24,7 @@ describe('gestures', () => {
     done();
   }, DATEPICKER_NAME);
   const cleanup = () => browser.executeAsync((a, done) => {
-    const els = document.body.querySelectorAll<Datepicker>(a);
+    const els = document.body.querySelectorAll(a) as unknown as Datepicker[];
 
     els.forEach(n => document.body.removeChild(n));
 

--- a/src/tests/app-datepicker/initial-render.spec.ts
+++ b/src/tests/app-datepicker/initial-render.spec.ts
@@ -35,7 +35,7 @@ describe('initial render', () => {
 
     afterEach(async () => {
       await browser.executeAsync((a, done) => {
-        const el = document.body.querySelector<Datepicker>(a)!;
+        const el = document.body.querySelector(a) as Datepicker;
 
         document.body.removeChild(el);
 
@@ -53,7 +53,7 @@ describe('initial render', () => {
 
     it(`renders initial content`, async () => {
       const prop: string = await browser.executeAsync(async (a, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
         done(n.locale);
       }, DATEPICKER_NAME);
@@ -68,13 +68,13 @@ describe('initial render', () => {
         calendarLabelContent,
         calendarDaysContents,
       ]: A = await browser.executeAsync(async (a, b, c, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
         const root = n.shadowRoot!;
 
-        const calendarLabel = root.querySelector<HTMLDivElement>(b)!;
+        const calendarLabel = root.querySelector(b) as HTMLDivElement;
         const calendarDays = Array.from(
-          root.querySelectorAll<HTMLTableCellElement>(c), o => o.textContent);
+          root.querySelectorAll(c), o => o.textContent);
 
         done([
           calendarLabel.outerHTML,
@@ -105,14 +105,14 @@ describe('initial render', () => {
         dateLabel,
         calendarDay,
       ]: A = await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
         // Reset focused date
         n.value = '';
 
         await n.updateComplete;
 
-        const n2 = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+        const n2 = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
         /**
          * NOTE: Get the today's date from the browser instead of
@@ -144,9 +144,9 @@ describe('initial render', () => {
 
     it(`focuses date based on 'value'`, async () => {
       const focusedDateContent: string = await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
-        const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+        const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
         done(focusedDate.outerHTML);
       }, DATEPICKER_NAME, toSelector('.day--focused'));
@@ -202,10 +202,10 @@ describe('initial render', () => {
 
     it(`renders initial content`, async () => {
       const yearListItemsContents: string[] = await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
         const yearListItems = Array.from(
-          n.shadowRoot!.querySelectorAll<HTMLButtonElement>(b), o => o.textContent);
+          n.shadowRoot!.querySelectorAll(b), o => o.textContent);
 
         done(yearListItems);
       }, DATEPICKER_NAME, '.year-list-view__list-item');
@@ -218,9 +218,9 @@ describe('initial render', () => {
 
     it(`focuses this year`, async () => {
       const focusedYearContent: string = await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
-        const focusedYear = n.shadowRoot!.querySelector<HTMLButtonElement>(b)!;
+        const focusedYear = n.shadowRoot!.querySelector(b) as HTMLButtonElement;
 
         done(focusedYear.outerHTML);
       }, DATEPICKER_NAME, '.year-list-view__list-item.year--selected');
@@ -273,7 +273,7 @@ describe('initial render', () => {
 
       for (const part of parts) {
         const result: A = await browser.executeAsync(async (a, [b, c], done) => {
-          const n = document.body.querySelector<Datepicker>(a)!;
+          const n = document.body.querySelector(a) as Datepicker;
 
           n.startView = c;
           await n.updateComplete;

--- a/src/tests/app-datepicker/keyboards.spec.ts
+++ b/src/tests/app-datepicker/keyboards.spec.ts
@@ -26,11 +26,11 @@ describe('keyboards', () => {
     await browserKeys(key, altKey);
 
     const [prop, content]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       await n.updateComplete;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b);
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -65,7 +65,7 @@ describe('keyboards', () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<Datepicker>(a);
+      const el = document.body.querySelector(a) as Datepicker;
 
       if (el) document.body.removeChild(el);
 
@@ -589,9 +589,9 @@ describe('keyboards', () => {
     const focusedDateSelector = toSelector('.day--focused');
     const getFocusedDate = (s: string): Promise<string> =>
       browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
 
-        done(n.shadowRoot?.querySelector<HTMLTableCellElement>(b)?.outerHTML ?? '');
+        done(n.shadowRoot?.querySelector(b)?.outerHTML ?? '');
       }, DATEPICKER_NAME, s);
 
     const initialFocusedDateContent = await getFocusedDate(focusedDateSelector);

--- a/src/tests/app-datepicker/mouses.spec.ts
+++ b/src/tests/app-datepicker/mouses.spec.ts
@@ -41,7 +41,7 @@ describe('mouses', () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<Datepicker>(a);
+      const el = document.body.querySelector(a) as Datepicker;
 
       if (el) document.body.removeChild(el);
 
@@ -53,8 +53,8 @@ describe('mouses', () => {
     await clickElements(['.btn__year-selector']);
 
     const hasYearListView: boolean = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
-      const yearListView = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+      const n = document.body.querySelector(a) as Datepicker;
+      const yearListView = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
       done(yearListView != null);
     }, DATEPICKER_NAME, '.datepicker-body__year-list-view');
@@ -70,9 +70,9 @@ describe('mouses', () => {
     });
 
     const hasCalendarView: boolean = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const calendarView = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+      const calendarView = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
       done(calendarView != null);
     }, DATEPICKER_NAME, '.datepicker-body__calendar-view');
@@ -89,9 +89,9 @@ describe('mouses', () => {
     ]);
 
     const hasYearListView: boolean = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const yearListView = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+      const yearListView = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
       done(yearListView != null);
     }, DATEPICKER_NAME, '.datepicker-body__year-list-view');
@@ -102,11 +102,11 @@ describe('mouses', () => {
       hasCalendarView,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const calendarView = root.querySelector<HTMLDivElement>(b)!;
-      const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+      const calendarView = root.querySelector(b) as HTMLDivElement;
+      const focusedDate = root.querySelector(c) as HTMLTableCellElement;
 
       done([
         calendarView != null,
@@ -143,13 +143,13 @@ describe('mouses', () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const yearSelectorButton = root.querySelector<HTMLButtonElement>(b)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const yearSelectorButton = root.querySelector(b) as HTMLButtonElement;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         n.value,
@@ -189,9 +189,9 @@ describe('mouses', () => {
       prop,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -219,12 +219,12 @@ describe('mouses', () => {
       focusedDateContent,
       calendarLabelContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       const root = n.shadowRoot!;
 
-      const focusedDate = root.querySelector<HTMLTableCellElement>(b)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const focusedDate = root.querySelector(b) as HTMLTableCellElement;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
 
       done([
         focusedDate.outerHTML,
@@ -259,13 +259,13 @@ describe('mouses', () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const prevMonthSelector = root.querySelector<HTMLButtonElement>(b)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const prevMonthSelector = root.querySelector(b) as HTMLButtonElement;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         prevMonthSelector == null,
@@ -310,13 +310,13 @@ describe('mouses', () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const nextMonthSelector = root.querySelector<HTMLButtonElement>(b)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const nextMonthSelector = root.querySelector(b) as HTMLButtonElement;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         nextMonthSelector == null,
@@ -360,13 +360,13 @@ describe('mouses', () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const prevMonthSelector = root.querySelector<HTMLButtonElement>(b)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const prevMonthSelector = root.querySelector(b) as HTMLButtonElement;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         prevMonthSelector == null,
@@ -410,13 +410,13 @@ describe('mouses', () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const nextMonthSelector = root.querySelector<HTMLButtonElement>(b)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const nextMonthSelector = root.querySelector(b) as HTMLButtonElement;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         nextMonthSelector == null,
@@ -447,10 +447,10 @@ describe('mouses', () => {
     await clickElements([`.btn__year-selector`], prepareOptions);
 
     const yearIdx: number = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       const allYears = Array.from(
-        n.shadowRoot!.querySelectorAll<HTMLButtonElement>(b), o => o.textContent!);
+        n.shadowRoot!.querySelectorAll(b), o => o.textContent!);
 
       done(allYears.findIndex(o => o.trim() === c));
     }, DATEPICKER_NAME, `.year-list-view__list-item`, newYear);
@@ -481,9 +481,9 @@ describe('mouses', () => {
       prop,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -520,9 +520,9 @@ describe('mouses', () => {
       prop,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -551,9 +551,9 @@ describe('mouses', () => {
       prop,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -571,8 +571,8 @@ describe('mouses', () => {
 
   const queryCalendarLabel = async () => {
     const label: string = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
-      const n2 = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+      const n = document.body.querySelector(a) as Datepicker;
+      const n2 = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
       done(n2.textContent);
     }, DATEPICKER_NAME, toSelector('.calendar-label'));
@@ -590,7 +590,7 @@ describe('mouses', () => {
     const calendarLabelContent = await queryCalendarLabel();
 
     await browser.executeAsync(async (a, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.firstDayOfWeek = 2;
       n.value = '2020-02-13';
@@ -610,12 +610,12 @@ describe('mouses', () => {
       calendarLabelContent3,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const calendarLabel3 = root.querySelector<HTMLDivElement>(b)!;
+      const calendarLabel3 = root.querySelector(b) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(c), o => o.textContent);
+        root.querySelectorAll(c), o => o.textContent);
 
       done([
         calendarLabel3.textContent,
@@ -646,7 +646,7 @@ describe('mouses', () => {
     const calendarLabelContent = await queryCalendarLabel();
 
     await browser.executeAsync(async (a, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.setAttribute('firstdayofweek', '2');
       n.setAttribute('value', '2020-02-13');
@@ -666,12 +666,12 @@ describe('mouses', () => {
       calendarLabelContent3,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const calendarLabel3 = root.querySelector<HTMLDivElement>(b)!;
+      const calendarLabel3 = root.querySelector(b) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(c), o => o.textContent);
+        root.querySelectorAll(c), o => o.textContent);
 
       done([
         calendarLabel3.textContent,
@@ -709,13 +709,13 @@ describe('mouses', () => {
       calendarLabelContent,
       calendarDaysContents,
     ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
-      const focusedDate = root.querySelector<HTMLTableCellElement>(b)!;
-      const calendarLabel = root.querySelector<HTMLDivElement>(c)!;
+      const focusedDate = root.querySelector(b) as HTMLTableCellElement;
+      const calendarLabel = root.querySelector(c) as HTMLDivElement;
       const calendarDays = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(d), o => o.textContent);
+        root.querySelectorAll(d), o => o.textContent);
 
       done([
         n.value,

--- a/src/tests/app-datepicker/properties.spec.ts
+++ b/src/tests/app-datepicker/properties.spec.ts
@@ -35,7 +35,7 @@ describe('properties', () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<Datepicker>(a)!;
+      const el = document.body.querySelector(a) as Datepicker;
 
       document.body.removeChild(el);
 
@@ -50,7 +50,7 @@ describe('properties', () => {
       `./src/tests/snapshots/${DATEPICKER_NAME}/properties-0-${browserName}.png`);
 
     await browser.executeAsync(async (a, done) => {
-      const el = document.body.querySelector<Datepicker>(a)!;
+      const el = document.body.querySelector(a) as Datepicker;
 
       el.min = '2020-01-15';
       el.value = '2020-01-17';
@@ -73,7 +73,7 @@ describe('properties', () => {
       disabledDateContent,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
       n.min = '2020-01-15';
@@ -81,10 +81,10 @@ describe('properties', () => {
 
       await n.updateComplete;
 
-      const disabledDates = Array.from(root.querySelectorAll<HTMLTableCellElement>(b));
+      const disabledDates = Array.from(root.querySelectorAll(b)) as HTMLTableCellElement[];
       const lastDisableDate = disabledDates[disabledDates.length - 1];
 
-      const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+      const focusedDate = root.querySelector(c) as HTMLTableCellElement;
 
       // Chrome requires more time to render
       await n.updateComplete;
@@ -122,7 +122,7 @@ describe('properties', () => {
       disabledDateContent,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
       n.min = '2000-01-01';
@@ -131,9 +131,9 @@ describe('properties', () => {
 
       await n.updateComplete;
 
-      const disabledDates = Array.from(root.querySelectorAll<HTMLTableCellElement>(b));
+      const disabledDates = Array.from(root.querySelectorAll(b)) as HTMLTableCellElement[];
 
-      const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+      const focusedDate = root.querySelector(c) as HTMLTableCellElement;
 
       // Chrome requires more time to render
       await n.updateComplete;
@@ -169,7 +169,7 @@ describe('properties', () => {
       prop,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.max = '2020-12-31';
@@ -177,7 +177,7 @@ describe('properties', () => {
 
       await n.updateComplete;
 
-      const focusedDate = n.shadowRoot!.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.value,
@@ -203,13 +203,13 @@ describe('properties', () => {
       attr,
       hasYearListView,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.startView = 'yearList';
 
       await n.updateComplete;
 
-      const yearListView = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+      const yearListView = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
       done([
         n.startView,
@@ -231,7 +231,7 @@ describe('properties', () => {
       firstWeekdayLabelContent,
       focusedDateContent,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
       n.min = '2000-01-01';
@@ -240,8 +240,8 @@ describe('properties', () => {
 
       await n.updateComplete;
 
-      const firstWeekdayLabel = root.querySelector<HTMLTableHeaderCellElement>(b)!;
-      const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+      const firstWeekdayLabel = root.querySelector(b) as HTMLTableCellElement;
+      const focusedDate = root.querySelector(c) as HTMLTableCellElement;
 
       done([
         n.firstDayOfWeek,
@@ -277,7 +277,7 @@ describe('properties', () => {
       weekNumberLabelContent,
       weekNumbersContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
       n.min = '2000-01-01';
@@ -286,9 +286,9 @@ describe('properties', () => {
 
       await n.updateComplete;
 
-      const weekNumberLabel = root.querySelector<HTMLTableHeaderCellElement>(b)!;
+      const weekNumberLabel = root.querySelector(b) as HTMLTableCellElement;
       const weekNumbers = Array.from(
-        root.querySelectorAll<HTMLTableCellElement>(c), o => o.outerHTML);
+        root.querySelectorAll(c), o => o.outerHTML);
 
       done([
         n.showWeekNumber,
@@ -328,7 +328,7 @@ describe('properties', () => {
       attr,
       weekNumbersContents,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -338,7 +338,7 @@ describe('properties', () => {
       await n.updateComplete;
 
       const weekNumbers = Array.from(
-        n.shadowRoot!.querySelectorAll<HTMLTableCellElement>(b), o => o.outerHTML);
+        n.shadowRoot!.querySelectorAll(b), o => o.outerHTML);
 
       done([
         n.weekNumberType,
@@ -369,7 +369,7 @@ describe('properties', () => {
       attr,
       cssDisplay,
     ]: A = await browser.executeAsync(async (a, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.landscape = true;
 
@@ -378,7 +378,7 @@ describe('properties', () => {
       done([
         n.landscape,
         n.getAttribute('landscape'),
-        getComputedStyle(n).display,
+        getComputedStyle(n as unknown as Element).display,
       ] as A);
     }, DATEPICKER_NAME);
 
@@ -395,7 +395,7 @@ describe('properties', () => {
       focusedDateContent,
       weekdayLabelsContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
       const root = n.shadowRoot!;
 
       n.min = '2000-01-01';
@@ -404,9 +404,9 @@ describe('properties', () => {
 
       await n.updateComplete;
 
-      const focusedDate = root.querySelector<HTMLTableCellElement>(b)!;
+      const focusedDate = root.querySelector(b) as HTMLTableCellElement;
       const weekdayLabels = Array.from(
-        root.querySelectorAll<HTMLTableHeaderCellElement>(c), o => o.outerHTML);
+        root.querySelectorAll(c), o => o.outerHTML);
 
       done([
         n.locale,
@@ -447,7 +447,7 @@ describe('properties', () => {
       prop,
       disabledDatesContents,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -456,7 +456,7 @@ describe('properties', () => {
       await n.updateComplete;
 
       const disabledDates = Array.from(
-        n.shadowRoot!.querySelectorAll<HTMLTableCellElement>(b), o => o.outerHTML);
+        n.shadowRoot!.querySelectorAll(b), o => o.outerHTML);
 
       done([
         n.disabledDays,
@@ -501,7 +501,7 @@ describe('properties', () => {
       prop,
       disabledDatesContents,
     ]: A = await browser.executeAsync(async (a, b, c, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -510,7 +510,7 @@ describe('properties', () => {
       await n.updateComplete;
 
       const disabledDates = Array.from(
-        n.shadowRoot!.querySelectorAll<HTMLTableCellElement>(c), o => o.outerHTML);
+        n.shadowRoot!.querySelectorAll(c), o => o.outerHTML);
 
       done([
         n.disabledDates,
@@ -534,19 +534,19 @@ describe('properties', () => {
   });
 
   it(`renders with defined 'inline'`, async () => {
-    type A = [boolean, null];
+    type A = [boolean, HTMLElement | null];
 
     const [
       prop,
       noDatepickerHeader,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.inline = true;
 
       await n.updateComplete;
 
-      const datepickerHeader = n.shadowRoot!.querySelector<HTMLDivElement>(b);
+      const datepickerHeader = n.shadowRoot!.querySelector(b) as HTMLDivElement | null;
 
       done([
         n.inline,
@@ -563,7 +563,7 @@ describe('properties', () => {
 
     const dragRatio = .5;
     const prop: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.dragRatio = b;
 
@@ -582,7 +582,7 @@ describe('properties', () => {
       prop,
       weekNumberLabelContent,
     ]: A = await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       n.min = '2000-01-01';
       n.value = '2020-01-15';
@@ -591,7 +591,7 @@ describe('properties', () => {
 
       await n.updateComplete;
 
-      const weekNumberLabel = n.shadowRoot!.querySelector<HTMLTableHeaderCellElement>(b)!;
+      const weekNumberLabel = n.shadowRoot!.querySelector(b) as HTMLTableCellElement;
 
       done([
         n.weekLabel,
@@ -628,7 +628,7 @@ describe('properties', () => {
         focusedDateContent,
         disabledDatesContent,
       ]: A = await browser.executeAsync(async (a, b, c, d, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
         const root = n.shadowRoot!;
 
         n.min = '2000-01-01';
@@ -639,9 +639,9 @@ describe('properties', () => {
 
         await n.updateComplete;
 
-        const focusedDate = root.querySelector<HTMLTableCellElement>(c)!;
+        const focusedDate = root.querySelector(c) as HTMLTableCellElement;
         const disabledDates = Array.from(
-          root.querySelectorAll<HTMLTableCellElement>(d), o => o.outerHTML);
+          root.querySelectorAll(d), o => o.outerHTML);
 
         done([
           n.firstDayOfWeek,

--- a/src/tests/app-datepicker/timezones.spec.ts
+++ b/src/tests/app-datepicker/timezones.spec.ts
@@ -30,7 +30,7 @@ describe('timezones', () => {
 
   afterEach(async () => {
     await browser.executeAsync((a, done) => {
-      const el = document.body.querySelector<Datepicker>(a)!;
+      const el = document.body.querySelector(a) as Datepicker;
 
       document.body.removeChild(el);
 
@@ -60,7 +60,7 @@ describe('timezones', () => {
     for (const n of allDateStrings) {
       const valueProp = await browser.executeAsync(
         async (a: string, b: string, done: (a: string) => void) => {
-          const el = document.body.querySelector<Datepicker>(a)!;
+          const el = document.body.querySelector(a) as unknown as Datepicker;
 
           el.value = b;
 

--- a/src/tests/helpers/interaction.ts
+++ b/src/tests/helpers/interaction.ts
@@ -7,8 +7,8 @@ import { toSelector } from './to-selector.js';
 const browserKeys = (elementName: string) =>
 async (keyCode: number, altKey: boolean = false) => {
   return browser.executeAsync(async (a, b, c, d, done) => {
-    const n = document.body.querySelector<Datepicker>(a)!;
-    const n2 = n.shadowRoot!.querySelector<HTMLDivElement>(b)!;
+    const n = document.body.querySelector(a) as Datepicker;
+    const n2 = n.shadowRoot!.querySelector(b) as HTMLDivElement;
 
     const opt: any = { keyCode: c, altKey: d };
     const ev = new CustomEvent('keyup', opt);
@@ -27,7 +27,7 @@ const clickElements = (elementName: string, isSafari: boolean) =>
 async (classes: string[], prepareOptions?: PrepareOptions) => {
   if (prepareOptions) {
     await browser.executeAsync(async (a, b, done) => {
-      const n = document.body.querySelector<Datepicker>(a)!;
+      const n = document.body.querySelector(a) as Datepicker;
 
       const { props, attrs }: PrepareOptions = b;
 
@@ -63,7 +63,7 @@ async (classes: string[], prepareOptions?: PrepareOptions) => {
   for (const cls of classes) {
     if (isSafari) {
       await browser.executeAsync(async (a, b, done) => {
-        const n = document.body.querySelector<Datepicker>(a)!;
+        const n = document.body.querySelector(a) as Datepicker;
         const n2: HTMLElement = n.shadowRoot!.querySelector(b)!;
 
         if (n2 instanceof HTMLButtonElement || n2.tagName === 'MWC-BUTTON') {
@@ -92,7 +92,7 @@ async (classes: string[], prepareOptions?: PrepareOptions) => {
 const focusCalendarsContainer = (elementName: string) =>
 async (prepareOptions?: PrepareOptions): Promise<string> => {
   return await browser.executeAsync(async (a, b, c, done) => {
-    const a1 = document.body.querySelector<Datepicker>(a)!;
+    const a1 = document.body.querySelector(a) as Datepicker;
 
     if (c) {
       const { props, attrs }: PrepareOptions = c;
@@ -112,7 +112,7 @@ async (prepareOptions?: PrepareOptions): Promise<string> => {
 
     await a1.updateComplete;
 
-    const b1 = a1.shadowRoot!.querySelector<HTMLElement>(b)!;
+    const b1 = a1.shadowRoot!.querySelector(b) as HTMLElement;
 
     b1.focus();
 
@@ -328,10 +328,10 @@ const dragCalendarsContainer = (elementName: string, elementName2?: string) => {
           };
         };
 
-        const a1 = document.body.querySelector<Datepicker>(a)!;
+        const a1 = document.body.querySelector(a) as Datepicker;
         const a2 = b == null ?
           a1 :
-          a1.shadowRoot!.querySelector<Datepicker>(b)!;
+          a1.shadowRoot!.querySelector(b) as Datepicker;
         const root = a2.shadowRoot!;
 
         if (f) {
@@ -353,7 +353,7 @@ const dragCalendarsContainer = (elementName: string, elementName2?: string) => {
         if (b) await a2.updateComplete;
         await a1.updateComplete;
 
-        const b1 = root.querySelector<HTMLElement>(c)!;
+        const b1 = root.querySelector(c) as HTMLElement;
 
         // Setup drag point
         const a1Rect = a1.getBoundingClientRect();
@@ -384,9 +384,9 @@ const dragCalendarsContainer = (elementName: string, elementName2?: string) => {
         await transitionComplete;
         await a1.updateComplete;
 
-        done(root.querySelector<HTMLDivElement>(d)?.textContent ?? '');
+        done(root.querySelector(d)?.textContent ?? '');
       } catch (err) {
-        done(err.stack);
+        done((err as Error).stack);
       }
     },
     elementName,

--- a/src/tests/helpers/sanitize-text.ts
+++ b/src/tests/helpers/sanitize-text.ts
@@ -53,6 +53,8 @@ export function sanitizeText(content: string, options?: SanitizeTextOptions): st
       /(?:aria-label="(.+?)").*?(?:abbr="(.+?)")/gi,
       (_, p1, p2) => `abbr="${p2}" aria-label="${p1}"`
     ) // Swap abbr and aria-label of th in MS Edge
+    .replace(/<!--\?lit\$[0-9]+\$-->|<!--\??-->/g, '') // lit expression comments
+    .replace(/<!--\?lit\$[0-9]+\$-->|<!--\??-->|lit\$[0-9]+\$/g, '') // lit expression markers
     .replace(/<!---->/g, '') // lit-html template placeholder
     .replace(/\r?\n/gi, '') // new lines in text
     .replace(/(\s?style-scope app-datepicker\s?)/gi, '') // ShadyDOM specific classes

--- a/src/tests/helpers/sanitize-text.ts
+++ b/src/tests/helpers/sanitize-text.ts
@@ -53,7 +53,6 @@ export function sanitizeText(content: string, options?: SanitizeTextOptions): st
       /(?:aria-label="(.+?)").*?(?:abbr="(.+?)")/gi,
       (_, p1, p2) => `abbr="${p2}" aria-label="${p1}"`
     ) // Swap abbr and aria-label of th in MS Edge
-    .replace(/<!--\?lit\$[0-9]+\$-->|<!--\??-->/g, '') // lit expression comments
     .replace(/<!--\?lit\$[0-9]+\$-->|<!--\??-->|lit\$[0-9]+\$/g, '') // lit expression markers
     .replace(/<!---->/g, '') // lit-html template placeholder
     .replace(/\r?\n/gi, '') // new lines in text

--- a/src/tests/helpers/sanitize-text.ts
+++ b/src/tests/helpers/sanitize-text.ts
@@ -60,5 +60,7 @@ export function sanitizeText(content: string, options?: SanitizeTextOptions): st
     .replace(/(\s?style-scope app-datepicker\s?)/gi, '') // ShadyDOM specific classes
     .replace(/(\s?scope="row"|scope="row"\s?)/g, '') // scope="row" attribute in all week labels
     .replace(/(\s?class=""|class=""\s?)/g, '') // empty `class` attribute set by ShadyDOM
-    .replace(/(\s?style=""|style=""\s?)/g, ''); // Unknown `style` set by Firefox
+    .replace(/(\s?style=""|style=""\s?)/g, '') // Unknown `style` set by Firefox
+    .replace(/class="(.+?)"/gi, (_, s) => `class="${s.trim()}"`) // lit classMap
+    ;
 }

--- a/src/tests/wdio.sl.config.ts
+++ b/src/tests/wdio.sl.config.ts
@@ -54,11 +54,11 @@ export const config: WdioConfig = {
         screenResolution: '1024x768',
       },
     },
-    {
-      ...baseCapability,
-      browserName: 'microsoftedge',
-      browserVersion: '18',
-    },
+    // {
+    //   ...baseCapability,
+    //   browserName: 'microsoftedge',
+    //   browserVersion: '18',
+    // },
 
     // {
     //   ...baseCapability,


### PR DESCRIPTION
## Changes

1. Upgrade to use `lit` to fix #202
1. Upgrade to latest `typescript` and `@material/mwc-button`
1. Update code due to updated dependencies
1. Update test sanitizer for `lit`
1. Remove unsupported browser