### PR TITLE
fix: move package to ESM-Only and fix package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,62 +34,50 @@
   "exports": {
     ".": {
       "types": "./dist/date-picker/app-date-picker.d.ts",
-      "import": "./dist/date-picker/app-date-picker.js",
       "default": "./dist/date-picker/app-date-picker.js"
     },
     "./app-date-picker": {
       "types": "./dist/date-picker/app-date-picker.d.ts",
-      "import": "./dist/date-picker/app-date-picker.js",
       "default": "./dist/date-picker/app-date-picker.js"
     },
     "./app-date-picker-dialog": {
       "types": "./dist/date-picker-dialog/app-date-picker-dialog.d.ts",
-      "import": "./dist/date-picker-dialog/app-date-picker-dialog.js",
       "default": "./dist/date-picker-dialog/app-date-picker-dialog.js"
     },
     "./app-date-picker-input": {
       "types": "./dist/date-picker-input/app-date-picker-input.d.ts",
-      "import": "./dist/date-picker-input/app-date-picker-input.js",
       "default": "./dist/date-picker-input/app-date-picker-input.js"
     },
     "./app-month-calendar": {
       "types": "./dist/month-calendar/app-month-calendar.d.ts",
-      "import": "./dist/month-calendar/app-month-calendar.js",
       "default": "./dist/month-calendar/app-month-calendar.js"
     },
     "./app-year-grid": {
       "types": "./dist/year-grid/app-year-grid.d.ts",
-      "import": "./dist/year-grid/app-year-grid.js",
       "default": "./dist/year-grid/app-year-grid.js"
     },
     "./date-picker": {
       "types": "./dist/date-picker/date-picker.d.ts",
-      "import": "./dist/date-picker/date-picker.js",
       "default": "./dist/date-picker/date-picker.js"
     },
     "./date-picker-dialog": {
       "types": "./dist/date-picker-dialog/date-picker-dialog.d.ts",
-      "import": "./dist/date-picker-dialog/date-picker-dialog.js",
       "default": "./dist/date-picker-dialog/date-picker-dialog.js"
     },
     "./date-picker-input": {
       "types": "./dist/date-picker-input/date-picker-input.d.ts",
-      "import": "./dist/date-picker-input/date-picker-input.js",
       "default": "./dist/date-picker-input/date-picker-input.js"
     },
     "./month-calendar": {
       "types": "./dist/month-calendar/month-calendar.d.ts",
-      "import": "./dist/month-calendar/month-calendar.js",
       "default": "./dist/month-calendar/month-calendar.js"
     },
     "./root-element": {
       "types": "./dist/root-element/root-element.d.ts",
-      "import": "./dist/root-element/root-element.js",
       "default": "./dist/root-element/root-element.js"
     },
     "./year-grid": {
       "types": "./dist/year-grid/year-grid.d.ts",
-      "import": "./dist/year-grid/year-grid.js",
       "default": "./dist/year-grid/year-grid.js"
     },
     "./date-picker-dialog/*": "./dist/date-picker-dialog/*",
@@ -104,6 +92,43 @@
   "main": "./dist/date-picker/app-date-picker.js",
   "module": "./dist/date-picker/app-date-picker.js",
   "typings": "./dist/date-picker/app-date-picker.d.ts",
+  "typesVersions": {
+    "*": {
+      "app-date-picker": [
+        "./dist/date-picker/app-date-picker.d.ts"
+      ],
+      "app-date-picker-dialog": [
+        "./dist/date-picker-dialog/app-date-picker-dialog.d.ts"
+      ],
+      "app-date-picker-input": [
+        "./dist/date-picker-input/app-date-picker-input.d.ts"
+      ],
+      "app-month-calendar": [
+        "./dist/month-calendar/app-month-calendar.d.ts"
+      ],
+      "app-year-grid": [
+        "./dist/year-grid/app-year-grid.d.ts"
+      ],
+      "date-picker": [
+        "./dist/date-picker/date-picker.d.ts"
+      ],
+      "date-picker-dialog": [
+        "./dist/date-picker-dialog/date-picker-dialog.d.ts"
+      ],
+      "date-picker-input": [
+        "./dist/date-picker-input/date-picker-input.d.ts"
+      ],
+      "month-calendar": [
+        "./dist/month-calendar/month-calendar.d.ts"
+      ],
+      "root-element": [
+        "./dist/root-element/root-element.d.ts"
+      ],
+      "year-grid": [
+        "./dist/year-grid/year-grid.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist/*.*js.map",
     "dist/*.*js",

--- a/src/date-picker-dialog/typings.ts
+++ b/src/date-picker-dialog/typings.ts
@@ -1,6 +1,6 @@
 import type { Dialog } from '@material/mwc-dialog';
 
-import type { ChangedProperties, DatePickerProperties } from '../typings';
+import type { ChangedProperties, DatePickerProperties } from '../typings.js';
 
 export type DatePickerDialogChangedProperties = ChangedProperties<DatePickerDialogProperties>;
 

--- a/src/date-picker-input/typings.ts
+++ b/src/date-picker-input/typings.ts
@@ -1,5 +1,5 @@
 import type { TextField } from '@material/mwc-textfield';
 
-import type { DatePickerProperties } from '../typings';
+import type { DatePickerProperties } from '../typings.js';
 
 export interface DatePickerInputProperties extends DatePickerProperties, Omit<TextField, keyof DatePickerProperties> {}


### PR DESCRIPTION
I cannot build `date-picker-input` on my local, once the corresponding dts generated, the subpackage types should be fixed: `dist/date-picker-input/date-picker-input.d.ts` missing.

Lit is using ESM-Only, you can check latest and 2.8.0 versions (v2.8.0 being used in 6 rc33):
- lit v3.1.1 types: https://arethetypeswrong.github.io/?p=lit%403.1.1
- lit v2.8.0 types: https://arethetypeswrong.github.io/?p=lit%402.8.0

Check screenshot in this comment: https://github.com/motss/app-datepicker/issues/222#issuecomment-1898572994

`pnpm build && pnpm pack`, go to https://arethetypeswrong.github.io/ and upload the tgz file: refresh page between builds.

EDIT: I can also include `"packageManager": "pnpm@8.14.1"` in the package.json

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/motss/app-datepicker/223)
<!-- Reviewable:end -->
