### PR TITLE
chore: exclude `nodemon` and `lit-ntml` build when installing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,5 +203,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "pnpm": {
+    "neverBuiltDependencies": ["lit-ntml", "nodemod"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+neverBuiltDependencies:
+  - lit-ntml
+  - nodemod
+
 dependencies:
   '@material/mwc-base':
     specifier: ^0.27.0
@@ -3898,7 +3902,6 @@ packages:
   /lit-ntml@3.0.6:
     resolution: {integrity: sha512-PTxjoB1rgwGkfd8lN8agw7MeCojG2voJRBl2G/HBWH6mwsFobqUs+8NSymwPuFCFaAOuxlIVn42aahi3NhD0yg==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
-    requiresBuild: true
     dependencies:
       parse5: 6.0.1
       tslib: 2.6.2
@@ -4148,7 +4151,6 @@ packages:
   /nodemod@3.0.6:
     resolution: {integrity: sha512-XsW1ydsY8Dh7IyBIVsF8QFVNlBOUHMEJ8BNLzj8G9O27/g3KqfvfGZ8LFP3cOFcksZQ7skQdNVsgx+A7E56wMg==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
-    requiresBuild: true
     dependencies:
       lit-ntml: 3.0.6
       lodash-es: 4.17.21


### PR DESCRIPTION
https://github.com/motss/lit-ntml/issues/81#issuecomment-1908017162

closes #222

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/motss/app-datepicker/224)
<!-- Reviewable:end -->
