### PR TITLE
Refactor styles and shadowRootOptions to use getter syntax

### DIFF
--- a/src/__demo__/demo-app.ts
+++ b/src/__demo__/demo-app.ts
@@ -17,37 +17,6 @@ import type { CustomEventDetail } from '../typings.js';
 
 @customElement('demo-app')
 export class DemoApp extends RootElement {
-  public static override styles = [
-    css`
-    :host {
-      display: block;
-
-      padding-bottom: 999px;
-    }
-    :host > * + * {
-      margin: 16px 0 0;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    app-date-picker {
-      border: 1px solid #000;
-    }
-    /* app-date-picker::part(today),
-    app-date-picker::part(today)::before,
-    app-date-picker::part(toyear)::before {
-      color: red;
-    } */
-
-    @media (prefers-color-scheme: dark) {
-      app-date-picker {
-        border-color: #fff;
-      }
-    }
-    `,
-  ];
   #dateUpdated = ({
     currentTarget,
     detail,
@@ -59,7 +28,6 @@ export class DemoApp extends RootElement {
       id,
     });
   };
-
   #showDialog = async (ev: MouseEvent) => {
     const { dataset } = ev.currentTarget as HTMLButtonElement;
     const dialog = this.query<AppDatePickerDialog>(`#${dataset.id}`);
@@ -76,14 +44,48 @@ export class DemoApp extends RootElement {
       valueAsNumber: new Date(dialog?.valueAsNumber as number),
     });
   };
+
   @state() _editable = false;
   @state() _outlined = false;
-
   @queryAsync(appDatePickerDialogName) dialog!: Promise<AppDatePickerDialog>;
 
   @queryAsync(appDatePickerDialogBaseName) dialogBase!: Promise<AppDatePickerDialogBase>;
 
   @queryAsync(appDatePickerInputName) input!: Promise<AppDatePickerInput>;
+
+  public static override get styles() {
+    return [
+      css`
+      :host {
+        display: block;
+  
+        padding-bottom: 999px;
+      }
+      :host > * + * {
+        margin: 16px 0 0;
+      }
+  
+      * {
+        box-sizing: border-box;
+      }
+  
+      app-date-picker {
+        border: 1px solid #000;
+      }
+      /* app-date-picker::part(today),
+      app-date-picker::part(today)::before,
+      app-date-picker::part(toyear)::before {
+        color: red;
+      } */
+  
+      @media (prefers-color-scheme: dark) {
+        app-date-picker {
+          border-color: #fff;
+        }
+      }
+      `,
+    ];
+  }
 
   protected override firstUpdated(_changedProperties: Map<number | string | symbol, unknown>): void {
       Object.defineProperty(globalThis, '__demoApp', {

--- a/src/date-picker-dialog/date-picker-dialog-base.ts
+++ b/src/date-picker-dialog/date-picker-dialog-base.ts
@@ -5,9 +5,11 @@ import { resetShadowRoot } from '../stylings.js';
 import { datePickerDialogBaseStyling } from './stylings.js';
 
 export class DatePickerDialogBase extends ElementMixin(Dialog) {
-  public static override styles = [
-    ...Dialog.styles,
-    resetShadowRoot,
-    datePickerDialogBaseStyling,
-  ];
+  public static override get styles() {
+    return [
+      ...Dialog.styles,
+      resetShadowRoot,
+      datePickerDialogBaseStyling,
+    ];
+  }
 }

--- a/src/date-picker-dialog/date-picker-dialog.ts
+++ b/src/date-picker-dialog/date-picker-dialog.ts
@@ -3,7 +3,7 @@ import '@material/mwc-dialog';
 import '../date-picker/app-date-picker.js';
 import './app-date-picker-dialog-base.js';
 
-import { html, nothing, type TemplateResult  } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 import { property, queryAsync, state } from 'lit/decorators.js';
 
 import type { AppDatePicker } from '../date-picker/app-date-picker.js';
@@ -20,11 +20,6 @@ import { datePickerDialogStyling } from './stylings.js';
 import type { DatePickerDialogChangedProperties, DatePickerDialogProperties, DialogClosedEventDetail, DialogClosingEventDetail } from './typings.js';
 
 export class DatePickerDialog extends DatePickerMixin(DatePickerMinMaxMixin(RootElement)) implements DatePickerDialogProperties {
-  public static override styles = [
-    baseStyling,
-    datePickerDialogStyling,
-  ];
-
   #isResetAction = false;
 
   #onClosed = async (ev: CustomEvent<DialogClosedEventDetail>): Promise<void> => {
@@ -34,6 +29,7 @@ export class DatePickerDialog extends DatePickerMixin(DatePickerMinMaxMixin(Root
     datePicker && (datePicker.startView = 'calendar');
     this.fire({ detail: ev.detail, type: 'closed' });
   };
+
   #onClosing = ({
     detail,
   }: CustomEvent<DialogClosingEventDetail>): void => {
@@ -58,11 +54,10 @@ export class DatePickerDialog extends DatePickerMixin(DatePickerMinMaxMixin(Root
     this.value = undefined;
   };
   #selectedDate: Date;
-
   #valueAsDate: Date;
+
   @queryAsync(appDatePickerName) private _datePicker!: Promise<AppDatePicker>;
   @state() private _rendered = false;
-
   @property({ type: String }) public confirmLabel = 'set';
 
   @property({ type: String }) public dismissLabel = 'cancel';
@@ -75,6 +70,13 @@ export class DatePickerDialog extends DatePickerMixin(DatePickerMinMaxMixin(Root
     super();
 
     this.#selectedDate = this.#valueAsDate = toResolvedDate();
+  }
+
+  public static override get styles() {
+    return [
+      baseStyling,
+      datePickerDialogStyling,
+    ];
   }
 
   protected $onDatePickerDateUpdated({

--- a/src/date-picker-input-surface/date-picker-input-surface.ts
+++ b/src/date-picker-input-surface/date-picker-input-surface.ts
@@ -13,12 +13,14 @@ const alwaysOpenElementSet = new Set([
 ]);
 
 export class DatePickerInputSurface extends ElementMixin(MenuSurface) {
-  public static override styles = [
-    ...MenuSurface.styles,
-    baseStyling,
-    resetShadowRoot,
-    DatePickerInputSurfaceStyling,
-  ];
+  public static override get styles() {
+    return [
+      ...MenuSurface.styles,
+      baseStyling,
+      resetShadowRoot,
+      DatePickerInputSurfaceStyling,
+    ];
+  }
 
   protected override onBodyClick(ev: MouseEvent) {
     const elements =

--- a/src/date-picker-input/date-picker-input.ts
+++ b/src/date-picker-input/date-picker-input.ts
@@ -27,13 +27,7 @@ import { datePickerInputStyling } from './stylings.js';
 import type { DatePickerInputProperties } from './typings.js';
 
 export class DatePickerInput extends ElementMixin(DatePickerMixin(DatePickerMinMaxMixin(TextField))) implements DatePickerInputProperties {
-  public static override styles = [
-    ...TextField.styles,
-    baseStyling,
-    datePickerInputStyling,
-  ];
   #disconnect: () => void = () => undefined;
-
   #focusElement: HTMLElement | undefined = undefined;
 
   /* c8 ignore start */
@@ -73,6 +67,7 @@ export class DatePickerInput extends ElementMixin(DatePickerMixin(DatePickerMinM
   };
 
   #lazyLoading = false;
+
   #onClosed = ({ detail }: CustomEvent): void => {
     this._open = false;
     this.fire({ detail, type: 'closed' });
@@ -122,7 +117,6 @@ export class DatePickerInput extends ElementMixin(DatePickerMixin(DatePickerMinM
     this.reset();
   };
   #picker: AppDatePicker | undefined = undefined;
-
   #updateValues = (value: Date | string): void => {
     if (value) {
       const valueDate = new Date(value);
@@ -133,12 +127,12 @@ export class DatePickerInput extends ElementMixin(DatePickerMixin(DatePickerMinM
       this.reset();
     }
   };
+
   #valueAsDate: Date | undefined;
   #valueFormatter = this.$toValueFormatter();
   @state() private _disabled = false;
   @state() private _lazyLoaded = false;
   @state() private _open = false;
-
   @queryAsync('.mdc-text-field__input') protected $input!: Promise<HTMLInputElement | null>;
 
   @queryAsync(appDatePickerInputSurfaceName) protected $inputSurface!: Promise<AppDatePickerInputSurface | null>;
@@ -150,6 +144,14 @@ export class DatePickerInput extends ElementMixin(DatePickerMixin(DatePickerMinM
   public override iconTrailing = 'clear';
 
   public override type = appDatePickerInputType;
+
+  public static override get styles() {
+    return [
+      ...TextField.styles,
+      baseStyling,
+      datePickerInputStyling,
+    ];
+  }
 
   protected $renderContent(): TemplateResult {
     warnUndefinedElement(appDatePickerInputSurfaceName);

--- a/src/date-picker/date-picker.ts
+++ b/src/date-picker/date-picker.ts
@@ -34,13 +34,6 @@ import { datePickerStyling } from './stylings.js';
 import type { DatePickerChangedProperties } from './typings.js';
 
 export class DatePicker extends DatePickerMixin(DatePickerMinMaxMixin(RootElement)) implements DatePickerProperties {
-  public static override styles = [
-    baseStyling,
-    resetShadowRoot,
-    datePickerStyling,
-    webkitScrollbarStyling,
-  ];
-
   #focusNavButtonWithKey = false;
 
   #formatters: Formatters;
@@ -230,10 +223,10 @@ export class DatePicker extends DatePickerMixin(DatePickerMinMaxMixin(RootElemen
     this._currentDate = new Date(this._currentDate.setUTCFullYear(year));
     this.startView = 'calendar';
   };
+
   #valueAsDate: Date;
   @state() private _currentDate: Date;
   @state() private _max: Date;
-
   @state() private _min: Date;
 
   @queryAsync('app-month-calendar') private readonly _monthCalendar!: Promise<AppMonthCalendar | null>;
@@ -260,6 +253,15 @@ export class DatePicker extends DatePickerMixin(DatePickerMinMaxMixin(RootElemen
     this._currentDate = new Date(todayDate);
     this.#formatters = toFormatters(this.locale);
     this.#valueAsDate = new Date(todayDate);
+  }
+
+  public static override get styles() {
+    return [
+      baseStyling,
+      resetShadowRoot,
+      datePickerStyling,
+      webkitScrollbarStyling,
+    ];
   }
 
   protected override async firstUpdated(): Promise<void> {

--- a/src/month-calendar/month-calendar.ts
+++ b/src/month-calendar/month-calendar.ts
@@ -17,24 +17,14 @@ import { monthCalendarStyling } from './stylings.js';
 import type { MonthCalendarData, MonthCalendarProperties, MonthCalendarRenderCalendarDayInit } from './typings.js';
 
 export class MonthCalendar extends RootElement implements MonthCalendarProperties {
-  public static override shadowRootOptions = {
-    ...RootElement.shadowRootOptions,
-    delegatesFocus: true,
-  };
-  public static override styles = [
-    baseStyling,
-    resetShadowRoot,
-    monthCalendarStyling,
-  ];
-
   #selectedDate: Date | undefined = undefined;
+
   /**
    * NOTE(motss): This is required to avoid selected date being focused on each update.
    * Selected date should ONLY be focused during navigation with keyboard, e.g.
    * initial render, switching between views, etc.
    */
   #shouldFocusSelectedDate = false;
-
   #updateSelectedDate = (event: KeyboardEvent): void => {
     const key = event.key as SupportedKey;
     const type = event.type as 'click' | 'keydown' | 'keyup';
@@ -130,7 +120,6 @@ export class MonthCalendar extends RootElement implements MonthCalendarPropertie
      */
     this.#selectedDate = undefined;
   };
-
   @property({ attribute: false }) public data?: MonthCalendarData;
 
   @queryAsync('.calendar-day[aria-selected="true"]') public selectedCalendarDay!: Promise<HTMLTableCellElement | null>;
@@ -156,6 +145,21 @@ export class MonthCalendar extends RootElement implements MonthCalendarPropertie
       todayLabel: labelToday,
       weekdays: [],
     };
+  }
+
+  public static override get shadowRootOptions() {
+    return {
+      ...RootElement.shadowRootOptions,
+      delegatesFocus: true,
+    };
+  }
+
+  public static override get styles() {
+    return [
+      baseStyling,
+      resetShadowRoot,
+      monthCalendarStyling,
+    ];
   }
 
   protected $renderCalendarDay({

--- a/src/year-grid-button/year-grid-button.ts
+++ b/src/year-grid-button/year-grid-button.ts
@@ -5,8 +5,10 @@ import { ElementMixin } from '../mixins/element-mixin.js';
 import { yearGridButtonStyling } from './stylings.js';
 
 export class YearGridButton extends ElementMixin(ButtonBase) {
-  static override styles = [
-    styles,
-    yearGridButtonStyling,
-  ];
+  static override get styles() {
+    return [
+      styles,
+      yearGridButtonStyling,
+    ];
+  }
 }

--- a/src/year-grid/year-grid.ts
+++ b/src/year-grid/year-grid.ts
@@ -14,14 +14,8 @@ import { toNextSelectedYear } from './to-next-selected-year.js';
 import type { YearGridChangedProperties, YearGridData, YearGridProperties, YearGridRenderButtonInit } from './typings.js';
 
 export class YearGrid extends RootElement implements YearGridProperties {
-  public static override styles = [
-    baseStyling,
-    resetButton,
-    resetShadowRoot,
-    yearGridStyling,
-  ];
-
   #todayYear: number;
+
   #updateYear = (event: KeyboardEvent): void => {
     if (event.type === 'keydown') {
       /**
@@ -77,7 +71,6 @@ export class YearGrid extends RootElement implements YearGridProperties {
       });
     }
   };
-
   @state() protected $focusingYear: number;
 
   @property({ attribute: false }) public data: YearGridData;
@@ -101,6 +94,15 @@ export class YearGrid extends RootElement implements YearGridProperties {
     };
 
     this.$focusingYear = this.#todayYear = todayDate.getUTCFullYear();
+  }
+
+  public static override get styles() {
+    return [
+      baseStyling,
+      resetButton,
+      resetShadowRoot,
+      yearGridStyling,
+    ];
   }
 
   protected $renderButton({


### PR DESCRIPTION
Fixes #225

[static initialization blocks](https://caniuse.com/mdn-javascript_classes_static_initialization_blocks) are not supported by Safari 15.6

I ran `npm run lint -- -f` before committing, and I see that it moved these static property declarations around in the classes, I'm not sure if that's desired.